### PR TITLE
Modify URL parsing on fetch

### DIFF
--- a/.changeset/tiny-forks-end.md
+++ b/.changeset/tiny-forks-end.md
@@ -1,0 +1,5 @@
+---
+"@osdk/shared.net.platformapi": minor
+---
+
+Update fetch function to parse urls correctly.

--- a/packages/shared.net.platformapi/src/foundryPlatformFetch.ts
+++ b/packages/shared.net.platformapi/src/foundryPlatformFetch.ts
@@ -99,7 +99,7 @@ async function apiFetch(
   requestMediaType?: string,
   responseMediaType?: string,
 ) {
-  const url = new URL(`/api${endpointPath}`, clientCtx.baseUrl);
+  const url = new URL(`api${endpointPath}`, clientCtx.baseUrl);
   for (const [key, value] of Object.entries(queryArguments || {})) {
     if (value == null) {
       continue;


### PR DESCRIPTION
Updating URL construction for platform fetch so we can use with different path names than basic stack name