### PR TITLE
Version Packages (beta)

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -34,6 +34,7 @@
     "@osdk/tool.release": "0.5.0"
   },
   "changesets": [
+    "mean-plums-pull",
     "tiny-forks-end"
   ]
 }

--- a/packages/foundry.admin/CHANGELOG.md
+++ b/packages/foundry.admin/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @osdk/foundry.admin
 
+## 2.6.0-beta.1
+
+### Minor Changes
+
+- 7e79126: Updates the response type of methods that returned Blob to return Response
+
+### Patch Changes
+
+- Updated dependencies [7e79126]
+  - @osdk/shared.net.platformapi@1.2.0-beta.1
+  - @osdk/foundry.core@2.6.0-beta.1
+
 ## 2.6.0-beta.0
 
 ### Patch Changes

--- a/packages/foundry.admin/package.json
+++ b/packages/foundry.admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry.admin",
-  "version": "2.6.0-beta.0",
+  "version": "2.6.0-beta.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry.aipagents/CHANGELOG.md
+++ b/packages/foundry.aipagents/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @osdk/foundry.aipagents
 
+## 2.6.0-beta.1
+
+### Minor Changes
+
+- 7e79126: Updates the response type of methods that returned Blob to return Response
+
+### Patch Changes
+
+- Updated dependencies [7e79126]
+  - @osdk/shared.net.platformapi@1.2.0-beta.1
+  - @osdk/foundry.core@2.6.0-beta.1
+
 ## 2.6.0-beta.0
 
 ### Patch Changes

--- a/packages/foundry.aipagents/package.json
+++ b/packages/foundry.aipagents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry.aipagents",
-  "version": "2.6.0-beta.0",
+  "version": "2.6.0-beta.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry.connectivity/CHANGELOG.md
+++ b/packages/foundry.connectivity/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @osdk/foundry.connectivity
 
+## 2.6.0-beta.1
+
+### Minor Changes
+
+- 7e79126: Updates the response type of methods that returned Blob to return Response
+
+### Patch Changes
+
+- Updated dependencies [7e79126]
+  - @osdk/shared.net.platformapi@1.2.0-beta.1
+  - @osdk/foundry.orchestration@2.6.0-beta.1
+  - @osdk/foundry.datasets@2.6.0-beta.1
+  - @osdk/foundry.core@2.6.0-beta.1
+
 ## 2.6.0-beta.0
 
 ### Patch Changes

--- a/packages/foundry.connectivity/package.json
+++ b/packages/foundry.connectivity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry.connectivity",
-  "version": "2.6.0-beta.0",
+  "version": "2.6.0-beta.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry.core/CHANGELOG.md
+++ b/packages/foundry.core/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @osdk/foundry.core
 
+## 2.6.0-beta.1
+
+### Minor Changes
+
+- 7e79126: Updates the response type of methods that returned Blob to return Response
+
+### Patch Changes
+
+- Updated dependencies [7e79126]
+  - @osdk/shared.net.platformapi@1.2.0-beta.1
+  - @osdk/foundry.geo@2.6.0-beta.1
+
 ## 2.6.0-beta.0
 
 ### Patch Changes

--- a/packages/foundry.core/package.json
+++ b/packages/foundry.core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry.core",
-  "version": "2.6.0-beta.0",
+  "version": "2.6.0-beta.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry.datasets/CHANGELOG.md
+++ b/packages/foundry.datasets/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @osdk/foundry.datasets
 
+## 2.6.0-beta.1
+
+### Minor Changes
+
+- 7e79126: Updates the response type of methods that returned Blob to return Response
+
+### Patch Changes
+
+- Updated dependencies [7e79126]
+  - @osdk/shared.net.platformapi@1.2.0-beta.1
+  - @osdk/foundry.filesystem@2.6.0-beta.1
+  - @osdk/foundry.core@2.6.0-beta.1
+
 ## 2.6.0-beta.0
 
 ### Patch Changes

--- a/packages/foundry.datasets/package.json
+++ b/packages/foundry.datasets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry.datasets",
-  "version": "2.6.0-beta.0",
+  "version": "2.6.0-beta.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry.filesystem/CHANGELOG.md
+++ b/packages/foundry.filesystem/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @osdk/foundry.filesystem
 
+## 2.6.0-beta.1
+
+### Minor Changes
+
+- 7e79126: Updates the response type of methods that returned Blob to return Response
+
+### Patch Changes
+
+- Updated dependencies [7e79126]
+  - @osdk/shared.net.platformapi@1.2.0-beta.1
+  - @osdk/foundry.core@2.6.0-beta.1
+
 ## 2.6.0-beta.0
 
 ### Patch Changes

--- a/packages/foundry.filesystem/package.json
+++ b/packages/foundry.filesystem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry.filesystem",
-  "version": "2.6.0-beta.0",
+  "version": "2.6.0-beta.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry.functions/CHANGELOG.md
+++ b/packages/foundry.functions/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @osdk/foundry.functions
 
+## 2.6.0-beta.1
+
+### Patch Changes
+
+- Updated dependencies [7e79126]
+  - @osdk/shared.net.platformapi@1.2.0-beta.1
+  - @osdk/foundry.core@2.6.0-beta.1
+
 ## 2.6.0-beta.0
 
 ### Patch Changes

--- a/packages/foundry.functions/package.json
+++ b/packages/foundry.functions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry.functions",
-  "version": "2.6.0-beta.0",
+  "version": "2.6.0-beta.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry.geo/CHANGELOG.md
+++ b/packages/foundry.geo/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @osdk/foundry.geo
 
+## 2.6.0-beta.1
+
+### Minor Changes
+
+- 7e79126: Updates the response type of methods that returned Blob to return Response
+
+### Patch Changes
+
+- Updated dependencies [7e79126]
+  - @osdk/shared.net.platformapi@1.2.0-beta.1
+
 ## 2.6.0-beta.0
 
 ### Patch Changes

--- a/packages/foundry.geo/package.json
+++ b/packages/foundry.geo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry.geo",
-  "version": "2.6.0-beta.0",
+  "version": "2.6.0-beta.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry.ontologies/CHANGELOG.md
+++ b/packages/foundry.ontologies/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @osdk/foundry.ontologies
 
+## 2.6.0-beta.1
+
+### Minor Changes
+
+- 7e79126: Updates the response type of methods that returned Blob to return Response
+
+### Patch Changes
+
+- Updated dependencies [7e79126]
+  - @osdk/shared.net.platformapi@1.2.0-beta.1
+
 ## 2.6.0-beta.0
 
 ### Patch Changes

--- a/packages/foundry.ontologies/package.json
+++ b/packages/foundry.ontologies/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry.ontologies",
-  "version": "2.6.0-beta.0",
+  "version": "2.6.0-beta.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry.orchestration/CHANGELOG.md
+++ b/packages/foundry.orchestration/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @osdk/foundry.orchestration
 
+## 2.6.0-beta.1
+
+### Minor Changes
+
+- 7e79126: Updates the response type of methods that returned Blob to return Response
+
+### Patch Changes
+
+- Updated dependencies [7e79126]
+  - @osdk/shared.net.platformapi@1.2.0-beta.1
+  - @osdk/foundry.filesystem@2.6.0-beta.1
+  - @osdk/foundry.datasets@2.6.0-beta.1
+  - @osdk/foundry.core@2.6.0-beta.1
+
 ## 2.6.0-beta.0
 
 ### Patch Changes

--- a/packages/foundry.orchestration/package.json
+++ b/packages/foundry.orchestration/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry.orchestration",
-  "version": "2.6.0-beta.0",
+  "version": "2.6.0-beta.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry.publicapis/CHANGELOG.md
+++ b/packages/foundry.publicapis/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @osdk/foundry.publicapis
 
+## 2.6.0-beta.1
+
+### Minor Changes
+
+- 7e79126: Updates the response type of methods that returned Blob to return Response
+
+### Patch Changes
+
+- Updated dependencies [7e79126]
+  - @osdk/shared.net.platformapi@1.2.0-beta.1
+  - @osdk/foundry.core@2.6.0-beta.1
+
 ## 2.6.0-beta.0
 
 ### Patch Changes

--- a/packages/foundry.publicapis/package.json
+++ b/packages/foundry.publicapis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry.publicapis",
-  "version": "2.6.0-beta.0",
+  "version": "2.6.0-beta.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry.streams/CHANGELOG.md
+++ b/packages/foundry.streams/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @osdk/foundry.streams
 
+## 2.6.0-beta.1
+
+### Minor Changes
+
+- 7e79126: Updates the response type of methods that returned Blob to return Response
+
+### Patch Changes
+
+- Updated dependencies [7e79126]
+  - @osdk/shared.net.platformapi@1.2.0-beta.1
+  - @osdk/foundry.filesystem@2.6.0-beta.1
+  - @osdk/foundry.datasets@2.6.0-beta.1
+  - @osdk/foundry.core@2.6.0-beta.1
+
 ## 2.6.0-beta.0
 
 ### Patch Changes

--- a/packages/foundry.streams/package.json
+++ b/packages/foundry.streams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry.streams",
-  "version": "2.6.0-beta.0",
+  "version": "2.6.0-beta.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry.thirdpartyapplications/CHANGELOG.md
+++ b/packages/foundry.thirdpartyapplications/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @osdk/foundry.thirdpartyapplications
 
+## 2.6.0-beta.1
+
+### Minor Changes
+
+- 7e79126: Updates the response type of methods that returned Blob to return Response
+
+### Patch Changes
+
+- Updated dependencies [7e79126]
+  - @osdk/shared.net.platformapi@1.2.0-beta.1
+  - @osdk/foundry.core@2.6.0-beta.1
+
 ## 2.6.0-beta.0
 
 ### Patch Changes

--- a/packages/foundry.thirdpartyapplications/package.json
+++ b/packages/foundry.thirdpartyapplications/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry.thirdpartyapplications",
-  "version": "2.6.0-beta.0",
+  "version": "2.6.0-beta.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/foundry/CHANGELOG.md
+++ b/packages/foundry/CHANGELOG.md
@@ -1,5 +1,29 @@
 # @osdk/foundry
 
+## 2.6.0-beta.1
+
+### Minor Changes
+
+- 7e79126: Updates the response type of methods that returned Blob to return Response
+
+### Patch Changes
+
+- Updated dependencies [7e79126]
+  - @osdk/foundry.thirdpartyapplications@2.6.0-beta.1
+  - @osdk/shared.net.platformapi@1.2.0-beta.1
+  - @osdk/foundry.orchestration@2.6.0-beta.1
+  - @osdk/foundry.connectivity@2.6.0-beta.1
+  - @osdk/foundry.filesystem@2.6.0-beta.1
+  - @osdk/foundry.ontologies@2.6.0-beta.1
+  - @osdk/foundry.publicapis@2.6.0-beta.1
+  - @osdk/foundry.aipagents@2.6.0-beta.1
+  - @osdk/foundry.datasets@2.6.0-beta.1
+  - @osdk/foundry.streams@2.6.0-beta.1
+  - @osdk/foundry.admin@2.6.0-beta.1
+  - @osdk/foundry.core@2.6.0-beta.1
+  - @osdk/foundry.geo@2.6.0-beta.1
+  - @osdk/foundry.functions@2.6.0-beta.1
+
 ## 2.6.0-beta.0
 
 ### Patch Changes

--- a/packages/foundry/package.json
+++ b/packages/foundry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry",
-  "version": "2.6.0-beta.0",
+  "version": "2.6.0-beta.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/internal.foundry.core/CHANGELOG.md
+++ b/packages/internal.foundry.core/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @osdk/internal.foundry.core
 
+## 2.6.0-beta.1
+
+### Minor Changes
+
+- 7e79126: Updates the response type of methods that returned Blob to return Response
+
+### Patch Changes
+
+- Updated dependencies [7e79126]
+  - @osdk/shared.net.platformapi@1.2.0-beta.1
+  - @osdk/internal.foundry.geo@2.6.0-beta.1
+
 ## 2.6.0-beta.0
 
 ### Patch Changes

--- a/packages/internal.foundry.core/package.json
+++ b/packages/internal.foundry.core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/internal.foundry.core",
-  "version": "2.6.0-beta.0",
+  "version": "2.6.0-beta.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/internal.foundry.datasets/CHANGELOG.md
+++ b/packages/internal.foundry.datasets/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @osdk/internal.foundry.datasets
 
+## 2.6.0-beta.1
+
+### Minor Changes
+
+- 7e79126: Updates the response type of methods that returned Blob to return Response
+
+### Patch Changes
+
+- Updated dependencies [7e79126]
+  - @osdk/shared.net.platformapi@1.2.0-beta.1
+  - @osdk/internal.foundry.core@2.6.0-beta.1
+
 ## 2.6.0-beta.0
 
 ### Patch Changes

--- a/packages/internal.foundry.datasets/package.json
+++ b/packages/internal.foundry.datasets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/internal.foundry.datasets",
-  "version": "2.6.0-beta.0",
+  "version": "2.6.0-beta.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/internal.foundry.geo/CHANGELOG.md
+++ b/packages/internal.foundry.geo/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @osdk/internal.foundry.geo
 
+## 2.6.0-beta.1
+
+### Minor Changes
+
+- 7e79126: Updates the response type of methods that returned Blob to return Response
+
+### Patch Changes
+
+- Updated dependencies [7e79126]
+  - @osdk/shared.net.platformapi@1.2.0-beta.1
+
 ## 2.6.0-beta.0
 
 ### Patch Changes

--- a/packages/internal.foundry.geo/package.json
+++ b/packages/internal.foundry.geo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/internal.foundry.geo",
-  "version": "2.6.0-beta.0",
+  "version": "2.6.0-beta.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/internal.foundry.ontologies/CHANGELOG.md
+++ b/packages/internal.foundry.ontologies/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @osdk/internal.foundry.ontologies
 
+## 2.6.0-beta.1
+
+### Minor Changes
+
+- 7e79126: Updates the response type of methods that returned Blob to return Response
+
+### Patch Changes
+
+- Updated dependencies [7e79126]
+  - @osdk/shared.net.platformapi@1.2.0-beta.1
+  - @osdk/internal.foundry.core@2.6.0-beta.1
+
 ## 2.6.0-beta.0
 
 ### Patch Changes

--- a/packages/internal.foundry.ontologies/package.json
+++ b/packages/internal.foundry.ontologies/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/internal.foundry.ontologies",
-  "version": "2.6.0-beta.0",
+  "version": "2.6.0-beta.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/internal.foundry.ontologiesv2/CHANGELOG.md
+++ b/packages/internal.foundry.ontologiesv2/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @osdk/internal.foundry.ontologiesv2
 
+## 2.6.0-beta.1
+
+### Minor Changes
+
+- 7e79126: Updates the response type of methods that returned Blob to return Response
+
+### Patch Changes
+
+- Updated dependencies [7e79126]
+  - @osdk/shared.net.platformapi@1.2.0-beta.1
+  - @osdk/internal.foundry.core@2.6.0-beta.1
+
 ## 2.6.0-beta.0
 
 ### Patch Changes

--- a/packages/internal.foundry.ontologiesv2/package.json
+++ b/packages/internal.foundry.ontologiesv2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/internal.foundry.ontologiesv2",
-  "version": "2.6.0-beta.0",
+  "version": "2.6.0-beta.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/internal.foundry/CHANGELOG.md
+++ b/packages/internal.foundry/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @osdk/foundry
 
+## 2.6.0-beta.1
+
+### Minor Changes
+
+- 7e79126: Updates the response type of methods that returned Blob to return Response
+
+### Patch Changes
+
+- Updated dependencies [7e79126]
+  - @osdk/internal.foundry.ontologiesv2@2.6.0-beta.1
+  - @osdk/internal.foundry.ontologies@2.6.0-beta.1
+  - @osdk/internal.foundry.datasets@2.6.0-beta.1
+  - @osdk/shared.net.platformapi@1.2.0-beta.1
+  - @osdk/internal.foundry.core@2.6.0-beta.1
+  - @osdk/internal.foundry.geo@2.6.0-beta.1
+
 ## 2.6.0-beta.0
 
 ### Patch Changes

--- a/packages/internal.foundry/package.json
+++ b/packages/internal.foundry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/internal.foundry",
-  "version": "2.6.0-beta.0",
+  "version": "2.6.0-beta.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/platform-sdk-generator/CHANGELOG.md
+++ b/packages/platform-sdk-generator/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/platform-sdk-generator
 
+## 0.7.0-beta.0
+
+### Minor Changes
+
+- 7e79126: Updates the response type of methods that returned Blob to return Response
+
 ## 0.6.0
 
 ### Minor Changes

--- a/packages/platform-sdk-generator/package.json
+++ b/packages/platform-sdk-generator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/platform-sdk-generator",
   "private": true,
-  "version": "0.6.0",
+  "version": "0.7.0-beta.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/shared.net.platformapi/CHANGELOG.md
+++ b/packages/shared.net.platformapi/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/shared.net.platformapi
 
+## 1.2.0-beta.1
+
+### Minor Changes
+
+- 7e79126: Updates the response type of methods that returned Blob to return Response
+
 ## 1.2.0-beta.0
 
 ### Minor Changes

--- a/packages/shared.net.platformapi/package.json
+++ b/packages/shared.net.platformapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/shared.net.platformapi",
-  "version": "1.2.0-beta.0",
+  "version": "1.2.0-beta.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR was opened by automation. When you're ready to do a release, you can merge this and publish to npm yourself.
     If you're not ready to do a release yet, that's fine, whenever you re-run the release script in main, this PR will be updated.

⚠️⚠️⚠️⚠️⚠️⚠️

`main` is currently in **pre mode** so this branch has prereleases rather than normal releases. If you want to exit prereleases, run `changeset pre exit` on `main`.

⚠️⚠️⚠️⚠️⚠️⚠️

# Releases
## @osdk/foundry@2.6.0-beta.1

### Minor Changes

-   7e79126: Updates the response type of methods that returned Blob to return Response

### Patch Changes

-   Updated dependencies [7e79126]
    -   @osdk/foundry.thirdpartyapplications@2.6.0-beta.1
    -   @osdk/shared.net.platformapi@1.2.0-beta.1
    -   @osdk/foundry.orchestration@2.6.0-beta.1
    -   @osdk/foundry.connectivity@2.6.0-beta.1
    -   @osdk/foundry.filesystem@2.6.0-beta.1
    -   @osdk/foundry.ontologies@2.6.0-beta.1
    -   @osdk/foundry.publicapis@2.6.0-beta.1
    -   @osdk/foundry.aipagents@2.6.0-beta.1
    -   @osdk/foundry.datasets@2.6.0-beta.1
    -   @osdk/foundry.streams@2.6.0-beta.1
    -   @osdk/foundry.admin@2.6.0-beta.1
    -   @osdk/foundry.core@2.6.0-beta.1
    -   @osdk/foundry.geo@2.6.0-beta.1
    -   @osdk/foundry.functions@2.6.0-beta.1

## @osdk/foundry.admin@2.6.0-beta.1

### Minor Changes

-   7e79126: Updates the response type of methods that returned Blob to return Response

### Patch Changes

-   Updated dependencies [7e79126]
    -   @osdk/shared.net.platformapi@1.2.0-beta.1
    -   @osdk/foundry.core@2.6.0-beta.1

## @osdk/foundry.aipagents@2.6.0-beta.1

### Minor Changes

-   7e79126: Updates the response type of methods that returned Blob to return Response

### Patch Changes

-   Updated dependencies [7e79126]
    -   @osdk/shared.net.platformapi@1.2.0-beta.1
    -   @osdk/foundry.core@2.6.0-beta.1

## @osdk/foundry.connectivity@2.6.0-beta.1

### Minor Changes

-   7e79126: Updates the response type of methods that returned Blob to return Response

### Patch Changes

-   Updated dependencies [7e79126]
    -   @osdk/shared.net.platformapi@1.2.0-beta.1
    -   @osdk/foundry.orchestration@2.6.0-beta.1
    -   @osdk/foundry.datasets@2.6.0-beta.1
    -   @osdk/foundry.core@2.6.0-beta.1

## @osdk/foundry.core@2.6.0-beta.1

### Minor Changes

-   7e79126: Updates the response type of methods that returned Blob to return Response

### Patch Changes

-   Updated dependencies [7e79126]
    -   @osdk/shared.net.platformapi@1.2.0-beta.1
    -   @osdk/foundry.geo@2.6.0-beta.1

## @osdk/foundry.datasets@2.6.0-beta.1

### Minor Changes

-   7e79126: Updates the response type of methods that returned Blob to return Response

### Patch Changes

-   Updated dependencies [7e79126]
    -   @osdk/shared.net.platformapi@1.2.0-beta.1
    -   @osdk/foundry.filesystem@2.6.0-beta.1
    -   @osdk/foundry.core@2.6.0-beta.1

## @osdk/foundry.filesystem@2.6.0-beta.1

### Minor Changes

-   7e79126: Updates the response type of methods that returned Blob to return Response

### Patch Changes

-   Updated dependencies [7e79126]
    -   @osdk/shared.net.platformapi@1.2.0-beta.1
    -   @osdk/foundry.core@2.6.0-beta.1

## @osdk/foundry.geo@2.6.0-beta.1

### Minor Changes

-   7e79126: Updates the response type of methods that returned Blob to return Response

### Patch Changes

-   Updated dependencies [7e79126]
    -   @osdk/shared.net.platformapi@1.2.0-beta.1

## @osdk/foundry.ontologies@2.6.0-beta.1

### Minor Changes

-   7e79126: Updates the response type of methods that returned Blob to return Response

### Patch Changes

-   Updated dependencies [7e79126]
    -   @osdk/shared.net.platformapi@1.2.0-beta.1

## @osdk/foundry.orchestration@2.6.0-beta.1

### Minor Changes

-   7e79126: Updates the response type of methods that returned Blob to return Response

### Patch Changes

-   Updated dependencies [7e79126]
    -   @osdk/shared.net.platformapi@1.2.0-beta.1
    -   @osdk/foundry.filesystem@2.6.0-beta.1
    -   @osdk/foundry.datasets@2.6.0-beta.1
    -   @osdk/foundry.core@2.6.0-beta.1

## @osdk/foundry.publicapis@2.6.0-beta.1

### Minor Changes

-   7e79126: Updates the response type of methods that returned Blob to return Response

### Patch Changes

-   Updated dependencies [7e79126]
    -   @osdk/shared.net.platformapi@1.2.0-beta.1
    -   @osdk/foundry.core@2.6.0-beta.1

## @osdk/foundry.streams@2.6.0-beta.1

### Minor Changes

-   7e79126: Updates the response type of methods that returned Blob to return Response

### Patch Changes

-   Updated dependencies [7e79126]
    -   @osdk/shared.net.platformapi@1.2.0-beta.1
    -   @osdk/foundry.filesystem@2.6.0-beta.1
    -   @osdk/foundry.datasets@2.6.0-beta.1
    -   @osdk/foundry.core@2.6.0-beta.1

## @osdk/foundry.thirdpartyapplications@2.6.0-beta.1

### Minor Changes

-   7e79126: Updates the response type of methods that returned Blob to return Response

### Patch Changes

-   Updated dependencies [7e79126]
    -   @osdk/shared.net.platformapi@1.2.0-beta.1
    -   @osdk/foundry.core@2.6.0-beta.1

## @osdk/internal.foundry@2.6.0-beta.1

### Minor Changes

-   7e79126: Updates the response type of methods that returned Blob to return Response

### Patch Changes

-   Updated dependencies [7e79126]
    -   @osdk/internal.foundry.ontologiesv2@2.6.0-beta.1
    -   @osdk/internal.foundry.ontologies@2.6.0-beta.1
    -   @osdk/internal.foundry.datasets@2.6.0-beta.1
    -   @osdk/shared.net.platformapi@1.2.0-beta.1
    -   @osdk/internal.foundry.core@2.6.0-beta.1
    -   @osdk/internal.foundry.geo@2.6.0-beta.1

## @osdk/internal.foundry.core@2.6.0-beta.1

### Minor Changes

-   7e79126: Updates the response type of methods that returned Blob to return Response

### Patch Changes

-   Updated dependencies [7e79126]
    -   @osdk/shared.net.platformapi@1.2.0-beta.1
    -   @osdk/internal.foundry.geo@2.6.0-beta.1

## @osdk/internal.foundry.datasets@2.6.0-beta.1

### Minor Changes

-   7e79126: Updates the response type of methods that returned Blob to return Response

### Patch Changes

-   Updated dependencies [7e79126]
    -   @osdk/shared.net.platformapi@1.2.0-beta.1
    -   @osdk/internal.foundry.core@2.6.0-beta.1

## @osdk/internal.foundry.geo@2.6.0-beta.1

### Minor Changes

-   7e79126: Updates the response type of methods that returned Blob to return Response

### Patch Changes

-   Updated dependencies [7e79126]
    -   @osdk/shared.net.platformapi@1.2.0-beta.1

## @osdk/internal.foundry.ontologies@2.6.0-beta.1

### Minor Changes

-   7e79126: Updates the response type of methods that returned Blob to return Response

### Patch Changes

-   Updated dependencies [7e79126]
    -   @osdk/shared.net.platformapi@1.2.0-beta.1
    -   @osdk/internal.foundry.core@2.6.0-beta.1

## @osdk/internal.foundry.ontologiesv2@2.6.0-beta.1

### Minor Changes

-   7e79126: Updates the response type of methods that returned Blob to return Response

### Patch Changes

-   Updated dependencies [7e79126]
    -   @osdk/shared.net.platformapi@1.2.0-beta.1
    -   @osdk/internal.foundry.core@2.6.0-beta.1

## @osdk/shared.net.platformapi@1.2.0-beta.1

### Minor Changes

-   7e79126: Updates the response type of methods that returned Blob to return Response

## @osdk/foundry.functions@2.6.0-beta.1

### Patch Changes

-   Updated dependencies [7e79126]
    -   @osdk/shared.net.platformapi@1.2.0-beta.1
    -   @osdk/foundry.core@2.6.0-beta.1

## @osdk/platform-sdk-generator@0.7.0-beta.0

### Minor Changes

-   7e79126: Updates the response type of methods that returned Blob to return Response
