### PR TITLE
Fix @osdk/docs-spec-core types

### DIFF
--- a/.changeset/beige-boats-obey.md
+++ b/.changeset/beige-boats-obey.md
@@ -1,0 +1,5 @@
+---
+"@osdk/docs-spec-core": patch
+---
+
+Fix mistake in types

--- a/packages/docs-spec-core/src/spec.ts
+++ b/packages/docs-spec-core/src/spec.ts
@@ -67,7 +67,7 @@ export type SdkSnippets<S extends DocsSnippetsSpec> = {
   versions: {
     [version: string]: {
       snippets: {
-        [name in SnippetNames<S>]: BaseSnippet & { template: string };
+        [name in SnippetNames<S>]: Array<BaseSnippet & { template: string }>;
       };
     };
   };
@@ -78,15 +78,17 @@ export type ApiSnippets<S extends DocsSnippetsSpec> = {
   versions: {
     [version: string]: {
       snippets: {
-        [name in SnippetNames<S>]: BaseSnippet & {
-          endpoint: {
-            method: "GET" | "POST" | "PUT" | "DELETE" | "PATCH" | "WebSocket";
-            path: string;
-            headers: Record<string, string>;
-          };
-          body?: string;
-          response?: string;
-        };
+        [name in SnippetNames<S>]: Array<
+          BaseSnippet & {
+            endpoint: {
+              method: "GET" | "POST" | "PUT" | "DELETE" | "PATCH" | "WebSocket";
+              path: string;
+              headers: Record<string, string>;
+            };
+            body?: string;
+            response?: string;
+          }
+        >;
       };
     };
   };


### PR DESCRIPTION
These should have been typed as `Array<...>` from the start!