### PR TITLE
Support template helpers

### DIFF
--- a/.changeset/proud-emus-mate.md
+++ b/.changeset/proud-emus-mate.md
@@ -1,0 +1,5 @@
+---
+"@osdk/docs-spec-core": minor
+---
+
+Support helpers in snippets

--- a/packages/docs-spec-core/src/spec.ts
+++ b/packages/docs-spec-core/src/spec.ts
@@ -57,9 +57,11 @@ type VariablesForSnippetConfig<
 > = S["snippets"][T]["variables"];
 
 // For implementers
+
 export interface BaseSnippet {
   title?: string;
   status?: "ga" | "public-beta";
+  computedVariables?: Record<string, string>;
 }
 
 export type SdkSnippet = BaseSnippet & {
@@ -75,6 +77,7 @@ export type SdkSnippets<S extends DocsSnippetsSpec> = {
       };
     };
   };
+  helpers?: Record<string, (...args: any[]) => string>;
 };
 
 export type ApiSnippet = BaseSnippet & {
@@ -96,6 +99,7 @@ export type ApiSnippets<S extends DocsSnippetsSpec> = {
       };
     };
   };
+  helpers?: Record<string, (...args: any[]) => string>;
 };
 
 export type DocsSnippets<S extends DocsSnippetsSpec> =


### PR DESCRIPTION
To remove some of the language-specific dependencies we have in Dev Console and support fully externalising documentation, we need to allow templates to supply "helper" functions that can take a generic template value, perform some language-specific transformations, and then use that in code snippets.