### PR TITLE
Version Packages

### DIFF
--- a/.changeset/fast-lobsters-sparkle.md
+++ b/.changeset/fast-lobsters-sparkle.md
@@ -1,6 +1,0 @@
----
-"@osdk/platform-docs-spec": minor
-"@osdk/docs-spec-core": minor
----
-
-Fix types in docs packages

--- a/.changeset/hip-bears-vanish.md
+++ b/.changeset/hip-bears-vanish.md
@@ -1,7 +1,0 @@
----
-"@osdk/platform-sdk-generator": minor
-"@osdk/platform-docs-spec": minor
-"@osdk/docs-spec-core": minor
----
-
-Update helpers for platform docs and drop variables in platform docs spec

--- a/.changeset/proud-emus-mate.md
+++ b/.changeset/proud-emus-mate.md
@@ -1,5 +1,0 @@
----
-"@osdk/docs-spec-core": minor
----
-
-Support helpers in snippets

--- a/packages/docs-spec-core/CHANGELOG.md
+++ b/packages/docs-spec-core/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @osdk/docs-spec-core
 
+## 0.3.0
+
+### Minor Changes
+
+- 0965559: Fix types in docs packages
+- f355209: Update helpers for platform docs and drop variables in platform docs spec
+- 38b4379: Support helpers in snippets
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/docs-spec-core/package.json
+++ b/packages/docs-spec-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/docs-spec-core",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/platform-docs-spec/CHANGELOG.md
+++ b/packages/platform-docs-spec/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @osdk/platform-docs-spec
 
+## 0.4.0
+
+### Minor Changes
+
+- 0965559: Fix types in docs packages
+- f355209: Update helpers for platform docs and drop variables in platform docs spec
+
+### Patch Changes
+
+- Updated dependencies [0965559]
+- Updated dependencies [f355209]
+- Updated dependencies [38b4379]
+  - @osdk/docs-spec-core@0.3.0
+
 ## 0.3.0
 
 ### Minor Changes

--- a/packages/platform-docs-spec/package.json
+++ b/packages/platform-docs-spec/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/platform-docs-spec",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/platform-sdk-generator/CHANGELOG.md
+++ b/packages/platform-sdk-generator/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @osdk/platform-sdk-generator
 
+## 0.14.0
+
+### Minor Changes
+
+- f355209: Update helpers for platform docs and drop variables in platform docs spec
+
+### Patch Changes
+
+- Updated dependencies [0965559]
+- Updated dependencies [f355209]
+- Updated dependencies [38b4379]
+  - @osdk/platform-docs-spec@0.4.0
+  - @osdk/docs-spec-core@0.3.0
+
 ## 0.13.0
 
 ### Patch Changes

--- a/packages/platform-sdk-generator/package.json
+++ b/packages/platform-sdk-generator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/platform-sdk-generator",
   "private": true,
-  "version": "0.13.0",
+  "version": "0.14.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR was opened by automation. When you're ready to do a release, you can merge this and publish to npm yourself.
     If you're not ready to do a release yet, that's fine, whenever you re-run the release script in main, this PR will be updated.


# Releases
## @osdk/docs-spec-core@0.3.0

### Minor Changes

-   0965559: Fix types in docs packages
-   f355209: Update helpers for platform docs and drop variables in platform docs spec
-   38b4379: Support helpers in snippets

## @osdk/platform-docs-spec@0.4.0

### Minor Changes

-   0965559: Fix types in docs packages
-   f355209: Update helpers for platform docs and drop variables in platform docs spec

### Patch Changes

-   Updated dependencies [0965559]
-   Updated dependencies [f355209]
-   Updated dependencies [38b4379]
    -   @osdk/docs-spec-core@0.3.0

## @osdk/platform-sdk-generator@0.14.0

### Minor Changes

-   f355209: Update helpers for platform docs and drop variables in platform docs spec

### Patch Changes

-   Updated dependencies [0965559]
-   Updated dependencies [f355209]
-   Updated dependencies [38b4379]
    -   @osdk/platform-docs-spec@0.4.0
    -   @osdk/docs-spec-core@0.3.0
