### PR TITLE
Version Packages

### DIFF
--- a/.changeset/breezy-lobsters-wonder.md
+++ b/.changeset/breezy-lobsters-wonder.md
@@ -1,5 +1,0 @@
----
-"@osdk/docs-spec-core": minor
----
-
-Allow computed variable types to be any

--- a/packages/docs-spec-core/CHANGELOG.md
+++ b/packages/docs-spec-core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/docs-spec-core
 
+## 0.4.0
+
+### Minor Changes
+
+- 37b4958: Allow computed variable types to be any
+
 ## 0.3.0
 
 ### Minor Changes

--- a/packages/docs-spec-core/package.json
+++ b/packages/docs-spec-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/docs-spec-core",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/platform-docs-spec/CHANGELOG.md
+++ b/packages/platform-docs-spec/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/platform-docs-spec
 
+## 0.5.0
+
+### Patch Changes
+
+- Updated dependencies [37b4958]
+  - @osdk/docs-spec-core@0.4.0
+
 ## 0.4.0
 
 ### Minor Changes

--- a/packages/platform-docs-spec/package.json
+++ b/packages/platform-docs-spec/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/platform-docs-spec",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/platform-sdk-generator/CHANGELOG.md
+++ b/packages/platform-sdk-generator/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @osdk/platform-sdk-generator
 
+## 0.15.0
+
+### Patch Changes
+
+- Updated dependencies [37b4958]
+  - @osdk/docs-spec-core@0.4.0
+  - @osdk/platform-docs-spec@0.5.0
+
 ## 0.14.0
 
 ### Minor Changes

--- a/packages/platform-sdk-generator/package.json
+++ b/packages/platform-sdk-generator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/platform-sdk-generator",
   "private": true,
-  "version": "0.14.0",
+  "version": "0.15.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR was opened by automation. When you're ready to do a release, you can merge this and publish to npm yourself.
     If you're not ready to do a release yet, that's fine, whenever you re-run the release script in main, this PR will be updated.


# Releases
## @osdk/docs-spec-core@0.4.0

### Minor Changes

-   37b4958: Allow computed variable types to be any

## @osdk/platform-docs-spec@0.5.0

### Patch Changes

-   Updated dependencies [37b4958]
    -   @osdk/docs-spec-core@0.4.0

## @osdk/platform-sdk-generator@0.15.0

### Patch Changes

-   Updated dependencies [37b4958]
    -   @osdk/docs-spec-core@0.4.0
    -   @osdk/platform-docs-spec@0.5.0
