### PR TITLE
Switch to using plural names for resource names

### DIFF
--- a/.changeset/curvy-buses-press.md
+++ b/.changeset/curvy-buses-press.md
@@ -1,0 +1,5 @@
+---
+"@osdk/platform-sdk-generator": patch
+---
+
+Use the pluralName field on the IR instead of relying on pluralize to name resources

--- a/packages/platform-sdk-generator/package.json
+++ b/packages/platform-sdk-generator/package.json
@@ -31,7 +31,6 @@
     "@osdk/docs-spec-core": "workspace:*",
     "@osdk/platform-docs-spec": "workspace:*",
     "find-up": "^7.0.0",
-    "pluralize": "^8.0.0",
     "prettier": "^3.2.5",
     "remark": "^15.0.1",
     "tiny-invariant": "^1.3.3",
@@ -43,7 +42,6 @@
     "@osdk/monorepo.tsconfig": "workspace:~",
     "@types/mdast": "^4.0.4",
     "@types/node": "^20.16.11",
-    "@types/pluralize": "^0.0.33",
     "@types/yargs": "^17.0.29",
     "typescript": "^5.5.4"
   },

--- a/packages/platform-sdk-generator/src/generatePlatformSdkv2.ts
+++ b/packages/platform-sdk-generator/src/generatePlatformSdkv2.ts
@@ -17,7 +17,6 @@
 import type { ApiSpec } from "@osdk/platform-docs-spec";
 import fs from "node:fs/promises";
 import * as path from "node:path";
-import pluralizeWord from "pluralize";
 import { addPackagesToPackageJson } from "./addPackagesToPackageJson.js";
 import { copyright } from "./copyright.js";
 import { generateImports, SKIP } from "./generateImports.js";
@@ -324,17 +323,4 @@ async function createPackageJson(outputDir: string, name: string) {
       2,
     ),
   );
-}
-
-export function pluralize(s: string): string {
-  const parts = s.split(/(?=[A-Z])/);
-  if (!parts) throw new Error("Failed to pluralize");
-
-  const lastPart = parts[parts.length - 1] === "V2"
-    ? parts.length - 2
-    : parts.length - 1;
-
-  parts[lastPart] = pluralizeWord(parts[lastPart]);
-
-  return parts.join("");
 }

--- a/packages/platform-sdk-generator/src/generatePlatformSdkv2.ts
+++ b/packages/platform-sdk-generator/src/generatePlatformSdkv2.ts
@@ -83,7 +83,7 @@ export async function generatePlatformSdkV2(
           ns.paths.resourcesDir,
         ).split(path.sep).join("/");
 
-      const resourceName = pluralize(r.component);
+      const resourceName = r.pluralName;
       if (componentsGenerated.get(ns)!.some(c => c === resourceName)) {
         throw new Error(
           `Even the duplicated components aren't unique: ${resourceName}`,

--- a/packages/platform-sdk-generator/src/model/Model.ts
+++ b/packages/platform-sdk-generator/src/model/Model.ts
@@ -257,6 +257,7 @@ export class Model {
         component: r.component.localName,
         namespace: r.component.namespaceName,
         operations: r.operations.map(so => new Operation(so, this)),
+        pluralName: r.pluralName,
       });
   }
 }

--- a/packages/platform-sdk-generator/src/model/Resource.ts
+++ b/packages/platform-sdk-generator/src/model/Resource.ts
@@ -18,6 +18,7 @@ import type { Operation } from "./Operation.js";
 
 export interface Resource {
   component: string;
+  pluralName: string;
   namespace: string;
   operations: Operation[];
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -865,9 +865,6 @@ importers:
       find-up:
         specifier: ^7.0.0
         version: 7.0.0
-      pluralize:
-        specifier: ^8.0.0
-        version: 8.0.0
       prettier:
         specifier: ^3.2.5
         version: 3.2.5
@@ -896,9 +893,6 @@ importers:
       '@types/node':
         specifier: ^20.16.11
         version: 20.16.11
-      '@types/pluralize':
-        specifier: ^0.0.33
-        version: 0.0.33
       '@types/yargs':
         specifier: ^17.0.29
         version: 17.0.32
@@ -2262,9 +2256,6 @@ packages:
 
   '@types/node@22.7.4':
     resolution: {integrity: sha512-y+NPi1rFzDs1NdQHHToqeiX2TIS79SWEAw9GYhkkx8bD0ChpfqC+n2j5OXOCpzfojBEBt6DnEnnG9MY0zk1XLg==}
-
-  '@types/pluralize@0.0.33':
-    resolution: {integrity: sha512-JOqsl+ZoCpP4e8TDke9W79FDcSgPAR0l6pixx2JHkhnRjvShyYiAYw2LVsnA7K08Y6DeOnaU6ujmENO4os/cYg==}
 
   '@types/semver@7.5.8':
     resolution: {integrity: sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==}
@@ -4163,10 +4154,6 @@ packages:
   pkg-versions@4.0.0:
     resolution: {integrity: sha512-OXvLTyO2Nv1fENNaTfQ6f+5wbAwsNg6z8cEuFdtuRw15Eo8Dd4I4F+7knlp+V2hj6Ow3Wl7HTIg/SaznkydLJw==}
     engines: {node: '>=18'}
-
-  pluralize@8.0.0:
-    resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
-    engines: {node: '>=4'}
 
   possible-typed-array-names@1.0.0:
     resolution: {integrity: sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==}
@@ -6381,8 +6368,6 @@ snapshots:
       undici-types: 6.19.8
     optional: true
 
-  '@types/pluralize@0.0.33': {}
-
   '@types/semver@7.5.8': {}
 
   '@types/unist@2.0.10': {}
@@ -8542,8 +8527,6 @@ snapshots:
   pkg-versions@4.0.0:
     dependencies:
       package-json: 10.0.0
-
-  pluralize@8.0.0: {}
 
   possible-typed-array-names@1.0.0: {}
 


### PR DESCRIPTION
Plural names are enforced on the IR types for all resources. We swap from using pluralize to using the pluralName that comes back on the spec to avoid conflicts