### PR TITLE
Rebuild Platform SDK against stable API Gateway

### DIFF
--- a/.changeset/ninety-carpets-compete.md
+++ b/.changeset/ninety-carpets-compete.md
@@ -1,0 +1,28 @@
+---
+"@osdk/foundry.thirdpartyapplications": patch
+"@osdk/internal.foundry.ontologies": patch
+"@osdk/internal.foundry.datasets": patch
+"@osdk/foundry.orchestration": patch
+"@osdk/internal.foundry.core": patch
+"@osdk/foundry.connectivity": patch
+"@osdk/internal.foundry.geo": patch
+"@osdk/docs-spec-platform": patch
+"@osdk/foundry.datahealth": patch
+"@osdk/foundry.filesystem": patch
+"@osdk/foundry.ontologies": patch
+"@osdk/foundry.publicapis": patch
+"@osdk/foundry.sqlqueries": patch
+"@osdk/foundry.aipagents": patch
+"@osdk/foundry.functions": patch
+"@osdk/foundry.mediasets": patch
+"@osdk/foundry.datasets": patch
+"@osdk/internal.foundry": patch
+"@osdk/foundry.streams": patch
+"@osdk/foundry.widgets": patch
+"@osdk/foundry.admin": patch
+"@osdk/foundry.core": patch
+"@osdk/foundry.geo": patch
+"@osdk/foundry": patch
+---
+
+Downgrade platform SDK to only contain endpoints in stable version of API Gateway

--- a/packages/docs-spec-platform/package.json
+++ b/packages/docs-spec-platform/package.json
@@ -50,7 +50,7 @@
   "sls": {
     "dependencies": {
       "com.palantir.foundry.api:api-gateway": {
-        "minVersion": "1.1180.0",
+        "minVersion": "1.1178.0",
         "maxVersion": "1.x.x",
         "optional": false
       }

--- a/packages/foundry.admin/package.json
+++ b/packages/foundry.admin/package.json
@@ -53,7 +53,7 @@
   "sls": {
     "dependencies": {
       "com.palantir.foundry.api:api-gateway": {
-        "minVersion": "1.1180.0",
+        "minVersion": "1.1178.0",
         "maxVersion": "1.x.x",
         "optional": false
       }

--- a/packages/foundry.aipagents/package.json
+++ b/packages/foundry.aipagents/package.json
@@ -57,7 +57,7 @@
   "sls": {
     "dependencies": {
       "com.palantir.foundry.api:api-gateway": {
-        "minVersion": "1.1180.0",
+        "minVersion": "1.1178.0",
         "maxVersion": "1.x.x",
         "optional": false
       }

--- a/packages/foundry.aipagents/src/_errors.ts
+++ b/packages/foundry.aipagents/src/_errors.ts
@@ -328,25 +328,6 @@ export interface ObjectTypeRidsNotFound {
 }
 
 /**
-   * Some ontology types are configured for use by the Agent but could not be found.
-The types either do not exist or the client token does not have access.
-Object types and their link types can be checked by listing available object/link types through the API, or searching in Ontology Manager.
-   *
-   * Log Safety: SAFE
-   */
-export interface OntologyEntitiesNotFound {
-  errorCode: "NOT_FOUND";
-  errorName: "OntologyEntitiesNotFound";
-  errorInstanceId: string;
-  parameters: {
-    agentRid: unknown;
-    sessionRid: unknown;
-    objectTypeRids: unknown;
-    linkTypeRids: unknown;
-  };
-}
-
-/**
  * Failed to generate a response as the model rate limits were exceeded. Clients should wait and retry.
  *
  * Log Safety: UNSAFE

--- a/packages/foundry.aipagents/src/index.ts
+++ b/packages/foundry.aipagents/src/index.ts
@@ -97,7 +97,6 @@ export type {
   NoPublishedAgentVersion,
   ObjectTypeIdsNotFound,
   ObjectTypeRidsNotFound,
-  OntologyEntitiesNotFound,
   RateLimitExceeded,
   SessionExecutionFailed,
   SessionNotFound,

--- a/packages/foundry.connectivity/package.json
+++ b/packages/foundry.connectivity/package.json
@@ -58,7 +58,7 @@
   "sls": {
     "dependencies": {
       "com.palantir.foundry.api:api-gateway": {
-        "minVersion": "1.1180.0",
+        "minVersion": "1.1178.0",
         "maxVersion": "1.x.x",
         "optional": false
       }

--- a/packages/foundry.core/package.json
+++ b/packages/foundry.core/package.json
@@ -53,7 +53,7 @@
   "sls": {
     "dependencies": {
       "com.palantir.foundry.api:api-gateway": {
-        "minVersion": "1.1180.0",
+        "minVersion": "1.1178.0",
         "maxVersion": "1.x.x",
         "optional": false
       }

--- a/packages/foundry.datahealth/package.json
+++ b/packages/foundry.datahealth/package.json
@@ -56,7 +56,7 @@
   "sls": {
     "dependencies": {
       "com.palantir.foundry.api:api-gateway": {
-        "minVersion": "1.1180.0",
+        "minVersion": "1.1178.0",
         "maxVersion": "1.x.x",
         "optional": false
       }

--- a/packages/foundry.datasets/package.json
+++ b/packages/foundry.datasets/package.json
@@ -54,7 +54,7 @@
   "sls": {
     "dependencies": {
       "com.palantir.foundry.api:api-gateway": {
-        "minVersion": "1.1180.0",
+        "minVersion": "1.1178.0",
         "maxVersion": "1.x.x",
         "optional": false
       }

--- a/packages/foundry.filesystem/package.json
+++ b/packages/foundry.filesystem/package.json
@@ -53,7 +53,7 @@
   "sls": {
     "dependencies": {
       "com.palantir.foundry.api:api-gateway": {
-        "minVersion": "1.1180.0",
+        "minVersion": "1.1178.0",
         "maxVersion": "1.x.x",
         "optional": false
       }

--- a/packages/foundry.functions/package.json
+++ b/packages/foundry.functions/package.json
@@ -53,7 +53,7 @@
   "sls": {
     "dependencies": {
       "com.palantir.foundry.api:api-gateway": {
-        "minVersion": "1.1180.0",
+        "minVersion": "1.1178.0",
         "maxVersion": "1.x.x",
         "optional": false
       }

--- a/packages/foundry.geo/package.json
+++ b/packages/foundry.geo/package.json
@@ -52,7 +52,7 @@
   "sls": {
     "dependencies": {
       "com.palantir.foundry.api:api-gateway": {
-        "minVersion": "1.1180.0",
+        "minVersion": "1.1178.0",
         "maxVersion": "1.x.x",
         "optional": false
       }

--- a/packages/foundry.mediasets/package.json
+++ b/packages/foundry.mediasets/package.json
@@ -53,7 +53,7 @@
   "sls": {
     "dependencies": {
       "com.palantir.foundry.api:api-gateway": {
-        "minVersion": "1.1180.0",
+        "minVersion": "1.1178.0",
         "maxVersion": "1.x.x",
         "optional": false
       }

--- a/packages/foundry.ontologies/package.json
+++ b/packages/foundry.ontologies/package.json
@@ -54,7 +54,7 @@
   "sls": {
     "dependencies": {
       "com.palantir.foundry.api:api-gateway": {
-        "minVersion": "1.1180.0",
+        "minVersion": "1.1178.0",
         "maxVersion": "1.x.x",
         "optional": false
       }

--- a/packages/foundry.orchestration/package.json
+++ b/packages/foundry.orchestration/package.json
@@ -55,7 +55,7 @@
   "sls": {
     "dependencies": {
       "com.palantir.foundry.api:api-gateway": {
-        "minVersion": "1.1180.0",
+        "minVersion": "1.1178.0",
         "maxVersion": "1.x.x",
         "optional": false
       }

--- a/packages/foundry.publicapis/package.json
+++ b/packages/foundry.publicapis/package.json
@@ -53,7 +53,7 @@
   "sls": {
     "dependencies": {
       "com.palantir.foundry.api:api-gateway": {
-        "minVersion": "1.1180.0",
+        "minVersion": "1.1178.0",
         "maxVersion": "1.x.x",
         "optional": false
       }

--- a/packages/foundry.sqlqueries/package.json
+++ b/packages/foundry.sqlqueries/package.json
@@ -54,7 +54,7 @@
   "sls": {
     "dependencies": {
       "com.palantir.foundry.api:api-gateway": {
-        "minVersion": "1.1180.0",
+        "minVersion": "1.1178.0",
         "maxVersion": "1.x.x",
         "optional": false
       }

--- a/packages/foundry.streams/package.json
+++ b/packages/foundry.streams/package.json
@@ -55,7 +55,7 @@
   "sls": {
     "dependencies": {
       "com.palantir.foundry.api:api-gateway": {
-        "minVersion": "1.1180.0",
+        "minVersion": "1.1178.0",
         "maxVersion": "1.x.x",
         "optional": false
       }

--- a/packages/foundry.thirdpartyapplications/package.json
+++ b/packages/foundry.thirdpartyapplications/package.json
@@ -53,7 +53,7 @@
   "sls": {
     "dependencies": {
       "com.palantir.foundry.api:api-gateway": {
-        "minVersion": "1.1180.0",
+        "minVersion": "1.1178.0",
         "maxVersion": "1.x.x",
         "optional": false
       }

--- a/packages/foundry.widgets/package.json
+++ b/packages/foundry.widgets/package.json
@@ -53,7 +53,7 @@
   "sls": {
     "dependencies": {
       "com.palantir.foundry.api:api-gateway": {
-        "minVersion": "1.1180.0",
+        "minVersion": "1.1178.0",
         "maxVersion": "1.x.x",
         "optional": false
       }

--- a/packages/foundry/package.json
+++ b/packages/foundry/package.json
@@ -69,7 +69,7 @@
   "sls": {
     "dependencies": {
       "com.palantir.foundry.api:api-gateway": {
-        "minVersion": "1.1180.0",
+        "minVersion": "1.1178.0",
         "maxVersion": "1.x.x",
         "optional": false
       }

--- a/packages/internal.foundry.core/package.json
+++ b/packages/internal.foundry.core/package.json
@@ -53,7 +53,7 @@
   "sls": {
     "dependencies": {
       "com.palantir.foundry.api:api-gateway": {
-        "minVersion": "1.1180.0",
+        "minVersion": "1.1178.0",
         "maxVersion": "1.x.x",
         "optional": false
       }

--- a/packages/internal.foundry.datasets/package.json
+++ b/packages/internal.foundry.datasets/package.json
@@ -53,7 +53,7 @@
   "sls": {
     "dependencies": {
       "com.palantir.foundry.api:api-gateway": {
-        "minVersion": "1.1180.0",
+        "minVersion": "1.1178.0",
         "maxVersion": "1.x.x",
         "optional": false
       }

--- a/packages/internal.foundry.geo/package.json
+++ b/packages/internal.foundry.geo/package.json
@@ -52,7 +52,7 @@
   "sls": {
     "dependencies": {
       "com.palantir.foundry.api:api-gateway": {
-        "minVersion": "1.1180.0",
+        "minVersion": "1.1178.0",
         "maxVersion": "1.x.x",
         "optional": false
       }

--- a/packages/internal.foundry.ontologies/package.json
+++ b/packages/internal.foundry.ontologies/package.json
@@ -54,7 +54,7 @@
   "sls": {
     "dependencies": {
       "com.palantir.foundry.api:api-gateway": {
-        "minVersion": "1.1180.0",
+        "minVersion": "1.1178.0",
         "maxVersion": "1.x.x",
         "optional": false
       }

--- a/packages/internal.foundry/package.json
+++ b/packages/internal.foundry/package.json
@@ -58,7 +58,7 @@
   "sls": {
     "dependencies": {
       "com.palantir.foundry.api:api-gateway": {
-        "minVersion": "1.1180.0",
+        "minVersion": "1.1178.0",
         "maxVersion": "1.x.x",
         "optional": false
       }


### PR DESCRIPTION
Our previous Platform SDK was built against a version of API Gateway that has not fully rolled out across the fleet. This PR downgrades to only expose endpoints that are fully available.