### PR TITLE
Support specifying API Gateway version for OpenAPI spec

### DIFF
--- a/scripts/getOpenApiIr.sh
+++ b/scripts/getOpenApiIr.sh
@@ -2,28 +2,73 @@
 
 set -eu
 
-# Define the necessary directories and files
-SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-mkdir -p "${SCRIPT_DIR}/../tmp"
+print_help() {
+    cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
 
-BUILD_DIR="${SCRIPT_DIR}/../tmp"
-DOWNLOAD_DIR="${BUILD_DIR}/api-gateway-bundle"
-EXTRACT_DIR="${BUILD_DIR}/api-gateway-ir"
+Options:
+  --api-gateway-version VERSION  Use the specified API Gateway version instead of resolving from Maven.
+  --help                        Show this help message and exit.
+EOF
+}
 
-MAVEN_CONJURE_GROUP_ID="com.palantir.foundry.api"
-MAVEN_CONJURE_ARTIFACT_ID="api-gateway-rosetta-bundle"
-MAVEN_REPO_PATH="${MAVEN_DIST_RELEASE}/$(echo "$MAVEN_CONJURE_GROUP_ID" | sed 's/\./\//g')/${MAVEN_CONJURE_ARTIFACT_ID}"
+parse_args() {
+    API_GATEWAY_VERSION=""
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --api-gateway-version)
+                API_GATEWAY_VERSION="$2"
+                shift 2
+                ;;
+            --help)
+                print_help
+                exit 0
+                ;;
+            *)
+                echo "Unknown option: $1"
+                print_help
+                exit 1
+                ;;
+        esac
+    done
+}
 
-API_GATEWAY_VERSION=$( wget -q -O - "${MAVEN_REPO_PATH}/maven-metadata.xml" | \
-    yq -p xml -r '.metadata.versioning.release' )
+resolve_api_gateway_version() {
+    if [[ -z "${API_GATEWAY_VERSION}" ]]; then
+        API_GATEWAY_VERSION=$(wget -q -O - "${MAVEN_REPO_PATH}/maven-metadata.xml" | \
+            yq -p xml -r '.metadata.versioning.release')
+    fi
+    echo "GATEWAY VERSION: ${API_GATEWAY_VERSION}"
+}
 
-echo "GATEWAY VERSION: ${API_GATEWAY_VERSION}"
+download_bundle() {
+    mkdir -p "${DOWNLOAD_DIR}"
+    wget -P "${DOWNLOAD_DIR}" "${MAVEN_REPO_PATH}/${API_GATEWAY_VERSION}/${MAVEN_CONJURE_ARTIFACT_ID}-${API_GATEWAY_VERSION}.sls.tgz"
+}
 
-mkdir -p "${DOWNLOAD_DIR}"
-wget -P "${DOWNLOAD_DIR}"  "${MAVEN_REPO_PATH}/${API_GATEWAY_VERSION}/${MAVEN_CONJURE_ARTIFACT_ID}-${API_GATEWAY_VERSION}.sls.tgz"
+extract_bundle() {
+    mkdir -p "${EXTRACT_DIR}"
+    tar -xf "${DOWNLOAD_DIR}/api-gateway-rosetta-bundle-${API_GATEWAY_VERSION}.sls.tgz" -C "${EXTRACT_DIR}" --strip-components=4 "api-gateway-rosetta-bundle-${API_GATEWAY_VERSION}/asset/palantir/ir-v2/combined-ir.json"
+    tar -xf "${DOWNLOAD_DIR}/api-gateway-rosetta-bundle-${API_GATEWAY_VERSION}.sls.tgz" -C "${EXTRACT_DIR}" --strip-components=2 "api-gateway-rosetta-bundle-${API_GATEWAY_VERSION}/deployment/manifest.yml"
+}
 
-mkdir -p "${EXTRACT_DIR}"
-# tar -xf "${DOWNLOAD_DIR}/api-gateway-rosetta-bundle-${API_GATEWAY_VERSION}.sls.tgz" -C "${EXTRACT_DIR}" --strip-components=4 "api-gateway-rosetta-bundle-${API_GATEWAY_VERSION}/asset/palantir/ir-v2/openapi-ir.json"
-# tar -xf "${DOWNLOAD_DIR}/api-gateway-rosetta-bundle-${API_GATEWAY_VERSION}.sls.tgz" -C "${EXTRACT_DIR}" --strip-components=4 "api-gateway-rosetta-bundle-${API_GATEWAY_VERSION}/asset/palantir/ir-v2/v2.json"
-tar -xf "${DOWNLOAD_DIR}/api-gateway-rosetta-bundle-${API_GATEWAY_VERSION}.sls.tgz" -C "${EXTRACT_DIR}" --strip-components=4 "api-gateway-rosetta-bundle-${API_GATEWAY_VERSION}/asset/palantir/ir-v2/combined-ir.json"
-tar -xf "${DOWNLOAD_DIR}/api-gateway-rosetta-bundle-${API_GATEWAY_VERSION}.sls.tgz" -C "${EXTRACT_DIR}" --strip-components=2 "api-gateway-rosetta-bundle-${API_GATEWAY_VERSION}/deployment/manifest.yml"
+main() {
+    # Define the necessary directories and files
+    SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+    mkdir -p "${SCRIPT_DIR}/../tmp"
+
+    BUILD_DIR="${SCRIPT_DIR}/../tmp"
+    DOWNLOAD_DIR="${BUILD_DIR}/api-gateway-bundle"
+    EXTRACT_DIR="${BUILD_DIR}/api-gateway-ir"
+
+    MAVEN_CONJURE_GROUP_ID="com.palantir.foundry.api"
+    MAVEN_CONJURE_ARTIFACT_ID="api-gateway-rosetta-bundle"
+    MAVEN_REPO_PATH="${MAVEN_DIST_RELEASE}/$(echo "$MAVEN_CONJURE_GROUP_ID" | sed 's/\./\//g')/${MAVEN_CONJURE_ARTIFACT_ID}"
+
+    parse_args "$@"
+    resolve_api_gateway_version
+    download_bundle
+    extract_bundle
+}
+
+main "$@"


### PR DESCRIPTION
By default, our script uses the latest API Gateway version, which can delay our ability to actually update the docs until that version has rolled out across the fleet. This change allows us to specify an older API Gateway version, which in turn will let us immediately use newly published library versions in our frontend.

I also added a help statement and split this into functions.

Trivia: this change was generated by passing the following prompt to AI:

> Take the following script and add an optional --api-gateway-version flag that sets API_GATEWAY_VERSION directly. Also add a --help option and factor out the existing script parts into a couple of functions.

It's very good at cleaning up scripts and adding options flags, in case we need those in any other scripts :)