### PR TITLE
Fix multiple attached headers

### DIFF
--- a/.changeset/witty-cars-try.md
+++ b/.changeset/witty-cars-try.md
@@ -1,0 +1,5 @@
+---
+"@osdk/shared.net.platformapi": patch
+---
+
+Stop attaching multiple headers for binary data

--- a/packages/shared.net.platformapi/src/foundryPlatformFetch.ts
+++ b/packages/shared.net.platformapi/src/foundryPlatformFetch.ts
@@ -118,14 +118,6 @@ async function apiFetch(
   headersInit.set("Content-Type", requestMediaType ?? "application/json");
   headersInit.set("Accept", responseMediaType ?? "application/json");
 
-  if (headers) {
-    const { "Content-Type": contentTypeHeader, Accept: acceptHeader } = headers;
-
-    if (typeof acceptHeader === "string") {
-      headersInit.set("Accept", acceptHeader);
-    }
-  }
-
   Object.entries(headers || {}).forEach(([key, value]) => {
     if (key === "Content-Type" && typeof value === "string") {
       headersInit.set("Content-Type", value);

--- a/packages/shared.net.platformapi/src/foundryPlatformFetch.ts
+++ b/packages/shared.net.platformapi/src/foundryPlatformFetch.ts
@@ -118,8 +118,20 @@ async function apiFetch(
   headersInit.set("Content-Type", requestMediaType ?? "application/json");
   headersInit.set("Accept", responseMediaType ?? "application/json");
 
+  if (headers) {
+    const { "Content-Type": contentTypeHeader, Accept: acceptHeader } = headers;
+
+    if (typeof acceptHeader === "string") {
+      headersInit.set("Accept", acceptHeader);
+    }
+  }
+
   Object.entries(headers || {}).forEach(([key, value]) => {
-    if (value != null) {
+    if (key === "Content-Type" && typeof value === "string") {
+      headersInit.set("Content-Type", value);
+    } else if (key === "Accept" && typeof value === "string") {
+      headersInit.set("Accept", value);
+    } else if (value != null) {
       headersInit.append(key, value.toString());
     }
   });


### PR DESCRIPTION
A user reported an issue that for the uploadAttachment endpoint in the OSDK, the Content-Header transmitted over the wire was a combination of "*/*" and the Content-Header of their Blob type. This is because our underlying fetch argument started appending headers we explicitly set beforehand. 