### PR TITLE
Ignore Gotham namespaces

### DIFF
--- a/.changeset/witty-cows-rush.md
+++ b/.changeset/witty-cows-rush.md
@@ -1,0 +1,5 @@
+---
+"@osdk/platform-sdk-generator": minor
+---
+
+Ignore new Gotham API namespaces from Foundry sdk generation

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,3 +1,0 @@
-# Default ignored files
-/shelf/
-/workspace.xml

--- a/packages/platform-sdk-generator/src/isIgnoredNamespace.ts
+++ b/packages/platform-sdk-generator/src/isIgnoredNamespace.ts
@@ -18,6 +18,12 @@ export function isIgnoredNamespace(ns?: string): boolean {
   switch (ns) {
     case "Operations":
       return true;
+    case "TargetWorkbench":
+      return true;
+    case "Gaia":
+      return true;
+    case "MapRendering"
+      return true;
   }
   return false;
 }

--- a/packages/platform-sdk-generator/src/isIgnoredNamespace.ts
+++ b/packages/platform-sdk-generator/src/isIgnoredNamespace.ts
@@ -22,7 +22,7 @@ export function isIgnoredNamespace(ns?: string): boolean {
       return true;
     case "Gaia":
       return true;
-    case "MapRendering"
+    case "MapRendering":
       return true;
   }
   return false;


### PR DESCRIPTION
Context: new Gotham apis are actively being added to the same repo containing Foundry public apis. We don't want these new apis to show up in the Foundry typescript sdk

Ignored namespaces include: 
- Gaia
- MapRendering
- TargetWorkbench