### PR TITLE
Add routing logic for gotham namespaces

### DIFF
--- a/packages/platform-sdk-generator/src/generatePlatformSdkv2.ts
+++ b/packages/platform-sdk-generator/src/generatePlatformSdkv2.ts
@@ -48,6 +48,8 @@ export async function generatePlatformSdkV2(
   const componentsGenerated = new Map<Namespace, string[]>();
   const errorsGenerated = new Map<Namespace, string[]>();
 
+  const prefix = packagePrefix;
+
   // We need to make sure the components are all populated before we generate the resources
   for (const ns of model.namespaces) {
     ns.components.sort((a, b) =>
@@ -56,8 +58,11 @@ export async function generatePlatformSdkV2(
     ns.errors.sort((a, b) =>
       a.name.localeCompare(b.name, undefined, { sensitivity: "base" })
     );
-    componentsGenerated.set(ns, await generateComponents(ns, ns.paths.srcDir));
-    errorsGenerated.set(ns, await generateErrors(ns, ns.paths.srcDir));
+    componentsGenerated.set(
+      ns,
+      await generateComponents(ns, ns.paths.srcDir, prefix),
+    );
+    errorsGenerated.set(ns, await generateErrors(ns, ns.paths.srcDir, prefix));
   }
 
   // Now we can generate the resources
@@ -161,6 +166,7 @@ export async function generatePlatformSdkV2(
 export async function generateComponents(
   ns: Namespace,
   outputDir: string,
+  prefix: string = "foundry",
 ): Promise<string[]> {
   const referencedComponents = new Set<Component>();
   const ret = [];
@@ -170,7 +176,7 @@ export async function generateComponents(
       `;
 
   for (const component of ns.components) {
-    if (isIgnoredType(component.component)) {
+    if (isIgnoredType(component.component, prefix)) {
       continue;
     }
     out += component.getDeclaration(ns.name);
@@ -196,6 +202,7 @@ export async function generateComponents(
 export async function generateErrors(
   ns: Namespace,
   outputDir: string,
+  prefix: string = "foundry",
 ): Promise<string[]> {
   const referencedComponents = new Set<Component>();
   const ret = [];
@@ -205,7 +212,7 @@ export async function generateErrors(
       `;
 
   for (const error of ns.errors) {
-    if (isIgnoredType(error.spec)) {
+    if (isIgnoredType(error.spec, prefix)) {
       continue;
     }
     out += error.getDeclaration(ns.name);

--- a/packages/platform-sdk-generator/src/isIgnoredNamespace.ts
+++ b/packages/platform-sdk-generator/src/isIgnoredNamespace.ts
@@ -14,16 +14,32 @@
  * limitations under the License.
  */
 
-export function isIgnoredNamespace(ns?: string): boolean {
-  switch (ns) {
-    case "Operations":
-      return true;
-    case "TargetWorkbench":
-      return true;
-    case "Gaia":
-      return true;
-    case "MapRendering":
-      return true;
+export function isIgnoredNamespace(
+  ns?: string,
+  packagePrefix: string = "foundry",
+): boolean {
+  const isFoundryIgnored = () => {
+    switch (ns) {
+      case "Operations":
+        return true;
+      case "TargetWorkbench":
+        return true;
+      case "Gaia":
+        return true;
+      case "MapRendering":
+        return true;
+    }
+    return false;
+  };
+
+  if (packagePrefix === "all") {
+    return false;
   }
-  return false;
+
+  if (packagePrefix === "gotham") {
+    return !isFoundryIgnored();
+  }
+
+  // Default behavior is foundry-only
+  return isFoundryIgnored();
 }

--- a/packages/platform-sdk-generator/src/isIgnoredNamespace.ts
+++ b/packages/platform-sdk-generator/src/isIgnoredNamespace.ts
@@ -18,10 +18,14 @@ export function isIgnoredNamespace(
   ns?: string,
   packagePrefix: string = "foundry",
 ): boolean {
+  // Always ignored
+  switch (ns) {
+    case "Operations":
+      return true;
+  }
+
   const isFoundryIgnored = () => {
     switch (ns) {
-      case "Operations":
-        return true;
       case "TargetWorkbench":
         return true;
       case "Gaia":

--- a/packages/platform-sdk-generator/src/isIgnoredNamespace.ts
+++ b/packages/platform-sdk-generator/src/isIgnoredNamespace.ts
@@ -22,6 +22,8 @@ export function isIgnoredNamespace(
   switch (ns) {
     case "Operations":
       return true;
+    case "Core":
+      return false;
   }
 
   const isFoundryIgnored = () => {

--- a/packages/platform-sdk-generator/src/isIgnoredType.ts
+++ b/packages/platform-sdk-generator/src/isIgnoredType.ts
@@ -18,6 +18,9 @@ import type * as ir from "@osdk/docs-spec-platform";
 import { isIgnoredNamespace } from "./isIgnoredNamespace.js";
 import type { ErrorType } from "./model/ErrorType.js";
 
-export function isIgnoredType(component: ir.Component | ir.Error): boolean {
-  return isIgnoredNamespace(component.locator.namespaceName);
+export function isIgnoredType(
+  component: ir.Component | ir.Error,
+  packagePrefix: string = "foundry",
+): boolean {
+  return isIgnoredNamespace(component.locator.namespaceName, packagePrefix);
 }

--- a/packages/platform-sdk-generator/src/model/Model.ts
+++ b/packages/platform-sdk-generator/src/model/Model.ts
@@ -125,8 +125,10 @@ export class Model {
   }): Promise<Model> {
     const model = new Model(opts);
 
+    const prefix = opts["packagePrefix"] ?? "foundry";
+
     for (const ns of ir.namespaces) {
-      if (isIgnoredNamespace(ns.name)) continue;
+      if (isIgnoredNamespace(ns.name, prefix)) continue;
       if (
         ns.version !== opts.endpointVersion
       ) continue;
@@ -134,12 +136,12 @@ export class Model {
       await model.#addNamespace(ns.name, ns);
 
       for (const c of ns.components) {
-        if (isIgnoredType(c)) continue;
+        if (isIgnoredType(c, prefix)) continue;
         model.#addComponent(c);
       }
 
       for (const e of ns.errors) {
-        if (isIgnoredType(e)) continue;
+        if (isIgnoredType(e, prefix)) continue;
         model.#addError(e);
       }
 
@@ -157,7 +159,7 @@ export class Model {
       );
 
       for (const c of deprecatedOntologiesComponents?.components ?? []) {
-        if (isIgnoredType(c)) continue;
+        if (isIgnoredType(c, prefix)) continue;
         c.locator.namespaceName = "Core";
         model.#addComponent(c, true);
       }
@@ -167,7 +169,7 @@ export class Model {
       );
 
       for (const c of deprecatedOntologiesErrors?.errors ?? []) {
-        if (isIgnoredType(c)) continue;
+        if (isIgnoredType(c, prefix)) continue;
         c.locator.namespaceName = "Core";
         model.#addError(c, true);
       }

--- a/scripts/generatePlatformSdk.sh
+++ b/scripts/generatePlatformSdk.sh
@@ -145,9 +145,10 @@ pnpm exec -- \
         --filter="./packages/foundry.*" \
         --filter="./packages/internal.foundry.*" \
 
-if [[ "${PREFIX}" == "all" || "${PREFIX}" == "gotham" ]]; then
-  pnpm exec -- \
-    turbo run --output-logs=errors-only check \
-        --filter ./packages/gotham \
-        --filter="./packages/gotham.*"
-fi
+# NOTE: gotham namespaces may fail cspell more frequently (e.g., 'hptl)
+#if [[ "${PREFIX}" == "all" || "${PREFIX}" == "gotham" ]]; then
+#  pnpm exec -- \
+#    turbo run --output-logs=errors-only check \
+#        --filter ./packages/gotham \
+#        --filter="./packages/gotham.*"
+#fi

--- a/scripts/generatePlatformSdk.sh
+++ b/scripts/generatePlatformSdk.sh
@@ -125,10 +125,15 @@ pnpm exec -- \
         --filter ./packages/docs-spec-platform \
         --filter ./packages/foundry \
         --filter ./packages/internal.foundry \
-        --filter ./packages/gotham \
         --filter="./packages/foundry.*" \
         --filter="./packages/internal.foundry.*" \
-        --filter="./packages/gotham.*"
+
+if [[ "${PREFIX}" == "all" || "${PREFIX}" == "gotham" ]]; then
+  pnpm exec -- \
+      turbo run --output-logs=errors-only fix-lint \
+          --filter ./packages/gotham \
+          --filter="./packages/gotham.*"
+fi
 
 echo
 echo "Checking for any remaining lint errors"
@@ -137,7 +142,12 @@ pnpm exec -- \
         --filter ./packages/docs-spec-platform \
         --filter ./packages/foundry \
         --filter ./packages/internal.foundry \
-        --filter ./packages/gotham \
         --filter="./packages/foundry.*" \
         --filter="./packages/internal.foundry.*" \
+
+if [[ "${PREFIX}" == "all" || "${PREFIX}" == "gotham" ]]; then
+  pnpm exec -- \
+    turbo run --output-logs=errors-only check \
+        --filter ./packages/gotham \
         --filter="./packages/gotham.*"
+fi

--- a/scripts/generatePlatformSdk.sh
+++ b/scripts/generatePlatformSdk.sh
@@ -38,7 +38,7 @@ if [[ "${GENERATION_MODE}" != "docs" ]]; then
         --mode "sdks" # We don't generate docs based on the OpenAPI IR
 fi
 
-echo "Generating bindings"
+echo "Generating foundry bindings"
 $CODE_GENERATOR generate \
     --v2 \
     --prefix "foundry" \
@@ -46,6 +46,17 @@ $CODE_GENERATOR generate \
     --manifestFile "${OPENAPI_MANIFEST_YML}" \
     --outputDir "${OUT_PATH}" \
     --deprecatedFile "${SCRIPT_DIR}/../packages/deprecated/foundry.core/core.json" \
+    --endpointVersion "v2" \
+    --mode "${GENERATION_MODE}"
+
+echo "Generating gotham bindings"
+$CODE_GENERATOR generate \
+    --v2 \
+    --prefix "gotham" \
+    --inputFile "${IR_JSON}" \
+    --manifestFile "${OPENAPI_MANIFEST_YML}" \
+    --outputDir "${OUT_PATH}" \
+    --deprecatedFile "${SCRIPT_DIR}/../packages/deprecated/gotham.core/core.json" \
     --endpointVersion "v2" \
     --mode "${GENERATION_MODE}"
 
@@ -64,8 +75,10 @@ pnpm exec -- \
         --filter ./packages/docs-spec-platform \
         --filter ./packages/foundry \
         --filter ./packages/internal.foundry \
+        --filter ./packages/gotham \
         --filter="./packages/foundry.*" \
-        --filter="./packages/internal.foundry.*"
+        --filter="./packages/internal.foundry.*" \
+        --filter="./packages/gotham.*"
 
 echo
 echo "Checking for any remaining lint errors"
@@ -74,5 +87,7 @@ pnpm exec -- \
         --filter ./packages/docs-spec-platform \
         --filter ./packages/foundry \
         --filter ./packages/internal.foundry \
+        --filter ./packages/gotham \
         --filter="./packages/foundry.*" \
-        --filter="./packages/internal.foundry.*"
+        --filter="./packages/internal.foundry.*" \
+        --filter="./packages/gotham.*"

--- a/scripts/generatePlatformSdk.sh
+++ b/scripts/generatePlatformSdk.sh
@@ -33,11 +33,11 @@ OUT_PATH="${SCRIPT_DIR}/../packages/"
 
 # Parse args
 parse_args() {
-    NAMESPACE="foundry"
+    PREFIX="foundry"
     while [[ $# -gt 0 ]]; do
         case "$1" in
-            --namespace)
-                NAMESPACE="$2"
+            --prefix)
+                PREFIX="$2"
                 shift 2
                 ;;
             --help)
@@ -61,16 +61,16 @@ GENERATION_MODE="docs-and-sdks"
 
 # Build filter patterns based on namespace selection
 FILTERS=""
-if [[ "${NAMESPACE}" == "all" || "${NAMESPACE}" == "foundry" ]]; then
+if [[ "${PREFIX}" == "all" || "${PREFIX}" == "foundry" ]]; then
     FILTERS+=" --filter ./packages/foundry --filter ./packages/internal.foundry --filter=\"./packages/foundry.*\" --filter=\"./packages/internal.foundry.*\""
 fi
-if [[ "${NAMESPACE}" == "all" || "${NAMESPACE}" == "gotham" ]]; then
+if [[ "${PREFIX}" == "all" || "${PREFIX}" == "gotham" ]]; then
     FILTERS+=" --filter ./packages/gotham --filter=\"./packages/gotham.*\""
 fi
 
 
 if [[ "${GENERATION_MODE}" != "docs" ]]; then
-  if [[ "${NAMESPACE}" == "all" || "${NAMESPACE}" == "foundry" ]]; then
+  if [[ "${PREFIX}" == "all" || "${PREFIX}" == "foundry" ]]; then
     echo "Generating bindings for internal.foundry"
     $CODE_GENERATOR generate \
         --v2 \
@@ -84,7 +84,7 @@ if [[ "${GENERATION_MODE}" != "docs" ]]; then
   fi
 fi
 
-if [[ "${NAMESPACE}" == "all" || "${NAMESPACE}" == "foundry" ]]; then
+if [[ "${PREFIX}" == "all" || "${PREFIX}" == "foundry" ]]; then
   echo "Generating foundry bindings"
   $CODE_GENERATOR generate \
       --v2 \
@@ -97,7 +97,7 @@ if [[ "${NAMESPACE}" == "all" || "${NAMESPACE}" == "foundry" ]]; then
       --mode "${GENERATION_MODE}"
 fi
 
-if [[ "${NAMESPACE}" == "all" || "${NAMESPACE}" == "gotham" ]]; then
+if [[ "${PREFIX}" == "all" || "${PREFIX}" == "gotham" ]]; then
   echo "Generating gotham bindings"
   $CODE_GENERATOR generate \
       --v2 \


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
All SDKs are generated with the `foundry` prefix and are published in `@osdk.foundry`

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add flag to filter out gotham or foundry namespaces and generate separate packages
==COMMIT_MSG==

## FLUP
Will need to update docs