### PR TITLE
Version Packages

### DIFF
--- a/.changeset/dirty-dancers-type.md
+++ b/.changeset/dirty-dancers-type.md
@@ -1,5 +1,0 @@
----
-"@osdk/docs-spec-sdk": minor
----
-
-Fix nearestNeighbor spec

--- a/.changeset/fresh-bobcats-knock.md
+++ b/.changeset/fresh-bobcats-knock.md
@@ -1,5 +1,0 @@
----
-"@osdk/platform-sdk-generator": minor
----
-
-The generation scripts will now generate both Gotham and Foundry packages automatically.

--- a/.changeset/lazy-roses-live.md
+++ b/.changeset/lazy-roses-live.md
@@ -1,5 +1,0 @@
----
-"@osdk/docs-spec-sdk": minor
----
-
-Add knn doc spec

--- a/packages/docs-spec-sdk/CHANGELOG.md
+++ b/packages/docs-spec-sdk/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/docs-spec-sdk
 
+## 0.6.0
+
+### Minor Changes
+
+- 1fb2aca: Fix nearestNeighbor spec
+- f289f64: Add knn doc spec
+
 ## 0.5.0
 
 ### Minor Changes

--- a/packages/docs-spec-sdk/package.json
+++ b/packages/docs-spec-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/docs-spec-sdk",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/platform-sdk-generator/CHANGELOG.md
+++ b/packages/platform-sdk-generator/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/platform-sdk-generator
 
+## 0.26.0
+
+### Minor Changes
+
+- 6472e27: The generation scripts will now generate both Gotham and Foundry packages automatically.
+
 ## 0.25.0
 
 ### Minor Changes

--- a/packages/platform-sdk-generator/package.json
+++ b/packages/platform-sdk-generator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/platform-sdk-generator",
   "private": true,
-  "version": "0.25.0",
+  "version": "0.26.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR was opened by automation. When you're ready to do a release, you can merge this and publish to npm yourself.
     If you're not ready to do a release yet, that's fine, whenever you re-run the release script in main, this PR will be updated.


# Releases
## @osdk/docs-spec-sdk@0.6.0

### Minor Changes

-   1fb2aca: Fix nearestNeighbor spec
-   f289f64: Add knn doc spec

## @osdk/platform-sdk-generator@0.26.0

### Minor Changes

-   6472e27: The generation scripts will now generate both Gotham and Foundry packages automatically.
