### PR TITLE
Version Packages

### DIFF
--- a/.changeset/unlucky-lies-develop.md
+++ b/.changeset/unlucky-lies-develop.md
@@ -1,5 +1,0 @@
----
-"@osdk/docs-spec-sdk": patch
----
-
-Cleanup the spec and rename to linkApiName

--- a/packages/docs-spec-sdk/CHANGELOG.md
+++ b/packages/docs-spec-sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/docs-spec-sdk
 
+## 0.9.0
+
+### Minor Changes
+
+- c233e66: Cleanup the spec and rename to linkApiName
+
 ## 0.8.0
 
 ### Minor Changes

--- a/packages/docs-spec-sdk/package.json
+++ b/packages/docs-spec-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/docs-spec-sdk",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR was opened by automation. When you're ready to do a release, you can merge this and publish to npm yourself.
     If you're not ready to do a release yet, that's fine, whenever you re-run the release script in main, this PR will be updated.


# Releases
## @osdk/docs-spec-sdk@0.9.0

### Minor Changes

-   c233e66: Cleanup the spec and rename to linkApiName
