### PR TITLE
Disable [skip ci] in autorelease commits

### DIFF
--- a/.palantir/autorelease.yml
+++ b/.palantir/autorelease.yml
@@ -4,6 +4,7 @@ options:
   repo_type: PNPM
   package_delimiter: "@"
   release_recommended_groups: true
+  disable_skip_ci: true
 
 groups:
   shared:


### PR DESCRIPTION
Without this, autorelease's release commit carries `[skip ci]` and the publish workflow never fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)