### PR TITLE
Add dist to published files

### DIFF
--- a/.changeset/stale-parrots-trade.md
+++ b/.changeset/stale-parrots-trade.md
@@ -1,0 +1,5 @@
+---
+"@osdk/foundry": patch
+---
+
+Publish .js and .d.ts bundles

--- a/.monorepolint.config.mjs
+++ b/.monorepolint.config.mjs
@@ -33,9 +33,12 @@ const LATEST_TYPESCRIPT_DEP = "^5.5.4";
 
 const DELETE_SCRIPT_ENTRY = { options: [undefined], fixValue: undefined };
 
+const DEFAULT_STANDARD_PACKAGE_OPTIONS = { tsVersion: LATEST_TYPESCRIPT_DEP };
+
 const nonStandardPackages = [
   "@osdk/monorepo.*", // internal monorepo packages
   "@osdk/platform-sdk-generator",
+  "@osdk/foundry", // Has a dist folder that should be published to NPM
 ];
 
 // Packages that should be private
@@ -241,7 +244,7 @@ function getTsconfigOptions(baseTsconfigPath, opts) {
  * }} options
  * @returns {import("@monorepolint/config").RuleModule[]}
  */
-function standardPackageRules(shared, options) {
+function standardPackageRules(shared, options, hasDist = false) {
   return [
     disallowWorkspaceCaret({ ...shared }),
 
@@ -320,6 +323,7 @@ function standardPackageRules(shared, options) {
             "build/esm",
             "build/browser",
             "CHANGELOG.md",
+            ...(hasDist === true ? ["dist"] : []),
             "package.json",
             "templates",
 
@@ -385,16 +389,22 @@ export default {
       excludePackages: [
         ...nonStandardPackages,
       ],
-    }, {
-      tsVersion: LATEST_TYPESCRIPT_DEP,
-    }),
+    }, DEFAULT_STANDARD_PACKAGE_OPTIONS),
 
     ...standardPackageRules({
       includePackages: ["@osdk/platform-sdk-generator"],
     }, {
-      tsVersion: LATEST_TYPESCRIPT_DEP,
+      ...DEFAULT_STANDARD_PACKAGE_OPTIONS,
       vitest: true,
     }),
+
+    ...standardPackageRules(
+      {
+        includePackages: ["@osdk/foundry"],
+      },
+      DEFAULT_STANDARD_PACKAGE_OPTIONS,
+      true,
+    ),
 
     packageEntry({
       options: {

--- a/packages/foundry/package.json
+++ b/packages/foundry/package.json
@@ -74,6 +74,7 @@
     "build/esm",
     "build/browser",
     "CHANGELOG.md",
+    "dist",
     "package.json",
     "templates",
     "*.d.ts"


### PR DESCRIPTION
## Before this PR
When merging and re-publishing https://github.com/palantir/foundry-platform-typescript/pull/287, I must have lost this line and therefore, no bundles are actually published in NPM.

## After this PR
Generated .js and d.ts bundles should be published to NPM.
==COMMIT_MSG==
Add dist folder to be published to NPM.
==COMMIT_MSG==

## Possible downsides?
N/A
