### PR TITLE
Fix

### DIFF
--- a/packages/foundry/package.json
+++ b/packages/foundry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/foundry",
-  "version": "2.60.0-rc1",
+  "version": "2.59.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Autorelease testing bumped this version https://github.com/palantir/foundry-platform-typescript/commit/22e9ccc699f215d5fcbc178abfd3f64f30b71a60#diff-382a5a4ac8fb05b7e3c3bc3de98419d0f8680ec68188d9ce55fe4aec7b4f01fc, setting it back to unblock releases