### PR TITLE
Revert "[High Priority] Excavator: Upgrade gradle-consistent-versions (#296)"

### DIFF
--- a/.husky/_/post-checkout
+++ b/.husky/_/post-checkout
@@ -1,3 +1,0 @@
-#!/bin/sh
-command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-checkout' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
-git lfs post-checkout "$@"

--- a/.husky/_/post-commit
+++ b/.husky/_/post-commit
@@ -1,3 +1,0 @@
-#!/bin/sh
-command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-commit' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
-git lfs post-commit "$@"

--- a/.husky/_/post-merge
+++ b/.husky/_/post-merge
@@ -1,3 +1,0 @@
-#!/bin/sh
-command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-merge' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
-git lfs post-merge "$@"

--- a/.husky/_/pre-push
+++ b/.husky/_/pre-push
@@ -1,3 +1,0 @@
-#!/bin/sh
-command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'pre-push' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
-git lfs pre-push "$@"


### PR DESCRIPTION
## Summary
- Reverts #296, which committed 4 git-lfs hook scripts into `.husky/_/` (`post-checkout`, `post-commit`, `post-merge`, `pre-push`).
- Those files were an accidental side effect of Excavator's environment running `git lfs install` against `core.hookspath=.husky/_`. The PR's stated purpose — bumping `gradle-consistent-versions` — is a no-op in this TypeScript repo.
- On main, every CI run regenerates `.husky/_/*` as husky stubs during `pnpm install`'s `prepare` script, then `git diff --exit-code` (`.github/workflows/ci.yml:81-82`) fails — breaking #296 itself and every subsequent PR build.

## Test plan
- [ ] CI "Build and Test" passes on all Node matrix legs (no diff after install/build)
- [ ] `.husky/_/` no longer exists in the tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)