### PR TITLE
Add ci-build umbrella job for branch protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - name: Verify build succeeded
+      - name: Verify dependent builds succeeded
         run: |
           if [[ "${{ needs.build.result }}" != "success" ]]; then
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,8 +84,8 @@ jobs:
       - name: Verify nothing added
         run: u="$(git ls-files --others --exclude-standard)" && test -z "$u"
 
-  ci-all:
-    name: ci-all
+  ci-build:
+    name: ci-build
     if: ${{ always() }}
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,3 +84,15 @@ jobs:
       - name: Verify nothing added
         run: u="$(git ls-files --others --exclude-standard)" && test -z "$u"
 
+  ci-all:
+    name: ci-all
+    if: ${{ always() }}
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify build succeeded
+        run: |
+          if [[ "${{ needs.build.result }}" != "success" ]]; then
+            exit 1
+          fi
+


### PR DESCRIPTION
## Summary
- Adds a single `ci-all` job that depends on `build` and succeeds only when every Node matrix leg (18/20/22/24) succeeds.
- Lets branch protection in [`devtools/github-automation`](https://github.palantir.build/devtools/github-automation/blob/develop/oss-settings/repositories/palantir.hcl) require one stable check (`ci-all`) instead of enumerating each `Build and Test (N)` context — so bumping the Node matrix doesn't require a github-automation change.
- `changesets` is intentionally **not** in `needs:` — auto-release PRs are expected to fail that check.

Motivation: PR #296 merged with `Build and Test (24)` failing because no CI contexts are currently required. Companion github-automation change will mark `ci-all` required after this merges. See also #298 (reverting #296).

## Test plan
- [ ] `ci-all` shows up as a status check on this PR and passes after all four `Build and Test (N)` legs pass
- [ ] If a build leg is manually failed (e.g. on a follow-up PR), `ci-all` reports failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)