### PR TITLE
make SpaceRid and ProjectRid assignable to FolderRid

### DIFF
--- a/.changeset/spacerid-projectrid-extend-folderrid.md
+++ b/.changeset/spacerid-projectrid-extend-folderrid.md
@@ -1,0 +1,5 @@
+---
+"@osdk/foundry.filesystem": patch
+---
+
+Make `SpaceRid` and `ProjectRid` assignable to `FolderRid` without a cast. A Space and a Project are both folders (see `FolderType = "FOLDER" | "SPACE" | "PROJECT"`), so callers can now pass a `Space.rid` directly to `Folders.children`, `Folders.get`, etc. instead of writing `space.rid as FolderRid`. Sibling rids remain mutually non-assignable.

--- a/packages/foundry.filesystem/src/_components.ts
+++ b/packages/foundry.filesystem/src/_components.ts
@@ -175,7 +175,9 @@ export interface Folder {
  *
  * Log Safety: SAFE
  */
-export type FolderRid = LooselyBrandedString<"FolderRid">;
+export type FolderRid = LooselyBrandedString<
+  "FolderRid" | "SpaceRid" | "ProjectRid"
+>;
 
 /**
    * A folder can be a regular Folder, a

--- a/packages/platform-sdk-generator/src/model/Component.ts
+++ b/packages/platform-sdk-generator/src/model/Component.ts
@@ -20,44 +20,15 @@ import type { Namespace } from "./Namespace.js";
 import { Type } from "./Type.js";
 
 /**
- * Models IS-A relationships between branded rid types so the generated SDK
- * matches the documented domain. Example: in the Filesystem namespace,
- * `FolderType = "FOLDER" | "SPACE" | "PROJECT"` — a Space and a Project are
- * both folders. We express that here so `SpaceRid` and `ProjectRid` are
- * one-way assignable to `FolderRid` without needing a cast at the call site.
- *
- * Outer key: IR `namespaceName`. Inner key: child rid `localName`. Value: the
- * parent rid names this rid IS-A.
- *
- * Encoding: when we emit a PARENT rid, we widen its `LooselyBrandedString`
- * brand union to include all of its declared children. Children themselves
- * stay as `LooselyBrandedString<"Child">`. This keeps `Child → Parent`
- * assignable (the child's brand literal is in the parent's union) while
- * leaving sibling children mutually non-assignable.
+ * Parent rid → children whose brand literals widen its `LooselyBrandedString`
+ * brand union. Keyed by IR `namespaceName` then parent `localName`. Makes
+ * `Child → Parent` one-way assignable; siblings stay mutually non-assignable.
  */
-const RID_SUBTYPES: Record<string, Record<string, readonly string[]>> = {
+const RID_CHILD_BRANDS: Record<string, Record<string, readonly string[]>> = {
   Filesystem: {
-    SpaceRid: ["FolderRid"],
-    ProjectRid: ["FolderRid"],
+    FolderRid: ["SpaceRid", "ProjectRid"],
   },
 };
-
-function getChildBrandsOf(
-  namespaceName: string,
-  parentLocalName: string,
-): string[] {
-  const namespaceMap = RID_SUBTYPES[namespaceName];
-  if (!namespaceMap) {
-    return [];
-  }
-  const children: string[] = [];
-  for (const [child, parents] of Object.entries(namespaceMap)) {
-    if (parents.includes(parentLocalName)) {
-      children.push(child);
-    }
-  }
-  return children;
-}
 
 export class Component extends Type {
   isComponent = true;
@@ -140,11 +111,11 @@ export class Component extends Type {
         // need to special case this since we use a branded type
         if (dt.builtin.type === "rid" || dt.builtin.type === "string") {
           const localName = component.locator.localName;
-          const childBrands = getChildBrandsOf(
-            component.locator.namespaceName,
-            localName,
-          );
-          const brandUnion = [localName, ...childBrands]
+          const children = dt.builtin.type === "rid"
+            ? RID_CHILD_BRANDS[component.locator.namespaceName]?.[localName]
+              ?? []
+            : [];
+          const brandUnion = [localName, ...children]
             .map((n) => `"${n}"`)
             .join(" | ");
           out += `LooselyBrandedString<${brandUnion}>`;

--- a/packages/platform-sdk-generator/src/model/Component.ts
+++ b/packages/platform-sdk-generator/src/model/Component.ts
@@ -19,6 +19,46 @@ import type { Model } from "./Model.js";
 import type { Namespace } from "./Namespace.js";
 import { Type } from "./Type.js";
 
+/**
+ * Models IS-A relationships between branded rid types so the generated SDK
+ * matches the documented domain. Example: in the Filesystem namespace,
+ * `FolderType = "FOLDER" | "SPACE" | "PROJECT"` — a Space and a Project are
+ * both folders. We express that here so `SpaceRid` and `ProjectRid` are
+ * one-way assignable to `FolderRid` without needing a cast at the call site.
+ *
+ * Outer key: IR `namespaceName`. Inner key: child rid `localName`. Value: the
+ * parent rid names this rid IS-A.
+ *
+ * Encoding: when we emit a PARENT rid, we widen its `LooselyBrandedString`
+ * brand union to include all of its declared children. Children themselves
+ * stay as `LooselyBrandedString<"Child">`. This keeps `Child → Parent`
+ * assignable (the child's brand literal is in the parent's union) while
+ * leaving sibling children mutually non-assignable.
+ */
+const RID_SUBTYPES: Record<string, Record<string, readonly string[]>> = {
+  Filesystem: {
+    SpaceRid: ["FolderRid"],
+    ProjectRid: ["FolderRid"],
+  },
+};
+
+function getChildBrandsOf(
+  namespaceName: string,
+  parentLocalName: string,
+): string[] {
+  const namespaceMap = RID_SUBTYPES[namespaceName];
+  if (!namespaceMap) {
+    return [];
+  }
+  const children: string[] = [];
+  for (const [child, parents] of Object.entries(namespaceMap)) {
+    if (parents.includes(parentLocalName)) {
+      children.push(child);
+    }
+  }
+  return children;
+}
+
 export class Component extends Type {
   isComponent = true;
   namespace: Namespace;
@@ -99,7 +139,15 @@ export class Component extends Type {
       case "builtin":
         // need to special case this since we use a branded type
         if (dt.builtin.type === "rid" || dt.builtin.type === "string") {
-          out += `LooselyBrandedString<"${component.locator.localName}">`;
+          const localName = component.locator.localName;
+          const childBrands = getChildBrandsOf(
+            component.locator.namespaceName,
+            localName,
+          );
+          const brandUnion = [localName, ...childBrands]
+            .map((n) => `"${n}"`)
+            .join(" | ");
+          out += `LooselyBrandedString<${brandUnion}>`;
         } else {
           out += ourType.getDeclaration(localNamespace);
         }


### PR DESCRIPTION
## Before this PR

In `@osdk/foundry.filesystem`, `SpaceRid` and `ProjectRid` are disjoint branded types from `FolderRid`, so users have to write a cast to call methods that accept any folder-typed rid:

```ts
await Folders.children(client, space.rid as FolderRid, { preview: true });
```

This is inconsistent with the documented domain — the same package defines:

```ts
export type FolderType = "FOLDER" | "SPACE" | "PROJECT";
```

A Space *is* a Folder, and a Project *is* a Folder. The type system should reflect that.

## After this PR

A `SpaceRid` or `ProjectRid` is now assignable to `FolderRid` with no cast:

```ts
const { data: spaces } = await Spaces.list(client, { preview: true });
const { data: children } = await Folders.children(client, spaces[0].rid, { preview: true });
```

Sibling rids remain mutually non-assignable, plain strings still flow into all three (loose brand preserved), and `FolderRid → SpaceRid` is still a type error.

• encode the IS-A relationship in the `platform-sdk-generator` via a small `RID_SUBTYPES` table; when a parent rid is emitted, its `LooselyBrandedString` brand union is widened to include its declared children
• apply the resulting shape to `FolderRid` in `@osdk/foundry.filesystem`: \`LooselyBrandedString<\"FolderRid\" | \"SpaceRid\" | \"ProjectRid\">\`
• children (`SpaceRid`, `ProjectRid`) stay as single-brand `LooselyBrandedString` so siblings don't collapse into each other

## Possible downsides?

This is strictly type-widening on `FolderRid` and behaviorally unchanged at runtime — the brand property is phantom (\`__LOOSE_BRAND?: T\` is never set on a runtime string). No existing code that compiled before should fail to compile.