### PR TITLE
Skip operations with unsupported response types in TS SDK generator

### DIFF
--- a/.changeset/angry-rice-marry.md
+++ b/.changeset/angry-rice-marry.md
@@ -1,0 +1,5 @@
+---
+"@osdk/platform-sdk-generator": patch
+---
+
+Skip operations with unsupported response types in TS SDK generator

--- a/packages/platform-sdk-generator/src/model/Model.test.ts
+++ b/packages/platform-sdk-generator/src/model/Model.test.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2024 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type * as ir from "@osdk/docs-spec-platform";
+import { describe, expect, it } from "vitest";
+import { unsupportedResponseTypeVariant } from "./Model.js";
+
+function operationWithResponseBody(body: unknown): ir.Operation {
+  return { http: { response: { body } } } as unknown as ir.Operation;
+}
+
+describe(unsupportedResponseTypeVariant, () => {
+  it("returns undefined for an ok body with a binary response type", () => {
+    const so = operationWithResponseBody({
+      type: "ok",
+      ok: {
+        responseType: { type: "binary", binary: { mediaType: "*/*" } },
+        required: true,
+      },
+    });
+    expect(unsupportedResponseTypeVariant(so)).toBeUndefined();
+  });
+
+  it("returns undefined for an ok body with a component response type", () => {
+    const so = operationWithResponseBody({
+      type: "ok",
+      ok: {
+        responseType: {
+          type: "component",
+          component: { mediaType: "application/json" },
+        },
+        required: true,
+      },
+    });
+    expect(unsupportedResponseTypeVariant(so)).toBeUndefined();
+  });
+
+  it("returns the variant name for an unknown ok response type", () => {
+    const so = operationWithResponseBody({
+      type: "ok",
+      ok: {
+        responseType: { type: "sse", sse: {} },
+        required: true,
+      },
+    });
+    expect(unsupportedResponseTypeVariant(so)).toBe("sse");
+  });
+
+  it("returns the variant name for any future unknown variant", () => {
+    const so = operationWithResponseBody({
+      type: "ok",
+      ok: {
+        responseType: { type: "websocket", websocket: {} },
+        required: true,
+      },
+    });
+    expect(unsupportedResponseTypeVariant(so)).toBe("websocket");
+  });
+
+  it("returns undefined for a noContent body", () => {
+    const so = operationWithResponseBody({
+      type: "noContent",
+      noContent: {},
+    });
+    expect(unsupportedResponseTypeVariant(so)).toBeUndefined();
+  });
+
+  it("returns undefined for an accepted body", () => {
+    const so = operationWithResponseBody({
+      type: "accepted",
+      accepted: {
+        responseType: {
+          type: "component",
+          component: { mediaType: "application/json" },
+        },
+      },
+    });
+    expect(unsupportedResponseTypeVariant(so)).toBeUndefined();
+  });
+});

--- a/packages/platform-sdk-generator/src/model/Model.ts
+++ b/packages/platform-sdk-generator/src/model/Model.ts
@@ -264,7 +264,18 @@ export class Model {
       .push({
         component: r.component.localName,
         namespace: r.component.namespaceName,
-        operations: r.operations.map(so => new Operation(so, this)),
+        operations: r.operations.flatMap(so => {
+          const unsupported = unsupportedResponseTypeVariant(so);
+          if (unsupported != null) {
+            // eslint-disable-next-line no-console
+            console.warn(
+              `Skipping ${ns.name}.${r.component.localName}.${so.name}: `
+                + `unsupported response type "${unsupported}"`,
+            );
+            return [];
+          }
+          return [new Operation(so, this)];
+        }),
         pluralName: r.pluralName,
       });
   }
@@ -283,4 +294,22 @@ export class Model {
       );
     }
   }
+}
+
+/**
+ * Returns the unsupported response-type variant name if the operation has an
+ * `ok` body whose `responseType` is anything other than `binary` or
+ * `component`. Returns `undefined` for supported operations.
+ *
+ * The IR types in `@osdk/docs-spec-platform` are static and don't know about
+ * variants added in newer IR releases (eg `sse`), so this guard reads the
+ * discriminator through a runtime cast.
+ */
+export function unsupportedResponseTypeVariant(
+  so: ir.Operation,
+): string | undefined {
+  const { body } = so.http.response;
+  if (body.type !== "ok") return undefined;
+  const variant = (body.ok.responseType as { type: string }).type;
+  return variant === "binary" || variant === "component" ? undefined : variant;
 }


### PR DESCRIPTION
## Before this PR
The TypeScript SDK generator only knows two `OkHttpResponseType` variants – `binary` and `component`. When an IR includes a new variant (eg the `sse` variant added in omniapi v0.768.0), `Operation.ts:62–97` falls through to the dead `ReferenceResponseType` path and either emits a literal `"undefined"` mime type in the generated client or throws a cryptic `TypeError` at codegen time. There's no way for a consumer to bump the IR ahead of a coordinated SDK update.

## After this PR
==COMMIT_MSG==
Skip operations with unsupported response types in TS SDK generator
==COMMIT_MSG==

At IR ingestion time (`Model.addResource`), the generator now reads each operation's `body.ok.responseType` discriminator. Any variant other than `binary` or `component` is logged via `console.warn` — naming the namespace, resource, operation, and variant — and excluded from the model. Sibling operations on the same resource still generate normally. The guard is forward-compatible: future variants are skipped automatically rather than corrupting output, unblocking IR bumps before per-SDK support lands.

## Possible downsides?
- Operations using new variants will silently disappear from the generated client until proper support is added per-SDK.