### PR TITLE
Add optional `arrayContains` template variable to docs-spec-sdk

### DIFF
--- a/.changeset/array-contains-filter-variable.md
+++ b/.changeset/array-contains-filter-variable.md
@@ -1,0 +1,5 @@
+---
+"@osdk/docs-spec-sdk": minor
+---
+
+Add optional `arrayContains` template variable for array element-subtype filter snippets.

--- a/packages/docs-spec-sdk/src/spec.ts
+++ b/packages/docs-spec-sdk/src/spec.ts
@@ -62,6 +62,7 @@ const ObjectTypeWithPropertyTemplateStrings = {
   rawPropertyValue: "required",
   rawPropertyValueIncremented: "required",
   structSubPropertyApiName: "optional",
+  arrayContains: "optional",
 } as const satisfies SnippetVariables;
 
 const RangeObjectTypeWithPropertyTemplateStrings = {


### PR DESCRIPTION
## Summary
Adds a new **optional** template variable `arrayContains` to the shared OSDK snippet spec (`@osdk/docs-spec-sdk`).

The variable is added to `ObjectTypeWithPropertyTemplateStrings`, right after the existing optional `structSubPropertyApiName`. Because nearly every filter template spreads `ObjectTypeWithPropertyTemplateStrings` (equality, in, range, startsWith, contains-terms, null, and, or, not, etc.), this single change makes `arrayContains` available to all of them.

Downstream SDKs (TypeScript specifically) can use this optional variable to render a `$contains` wrapper for array-property filters via Mustache conditionals, exactly like `structSubPropertyApiName` is used for struct sub-property filters today. No new snippet template names are introduced — `containsTemplate` already exists — and nothing is removed or renamed.

## Changes
- `packages/docs-spec-sdk/src/spec.ts`: add `arrayContains: "optional"` to `ObjectTypeWithPropertyTemplateStrings`.
- Changeset: `@osdk/docs-spec-sdk` **minor** bump (0.18.0 → 0.19.0).

## Why
Unblocks array element-subtype filter documentation snippets in osdk-ts and the Forge dev console.

## Verification
- `pnpm install` — up to date.
- `pnpm exec turbo run build --filter @osdk/docs-spec-sdk` — succeeds; generated `build/esm/spec.d.ts` and `build/browser/spec.d.ts` include `arrayContains: "optional"` on every filter template's variables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)