### PR TITLE
Patch content length bug attachment

### DIFF
--- a/.changeset/kind-avocados-hear.md
+++ b/.changeset/kind-avocados-hear.md
@@ -1,0 +1,7 @@
+---
+"@osdk/internal.foundry.ontologiesv2": minor
+"@osdk/internal.foundry.ontologies": minor
+"@osdk/foundry.ontologies": minor
+---
+
+Fix Attachment.upload fetch call

--- a/packages/foundry.ontologies/src/public/Attachment.ts
+++ b/packages/foundry.ontologies/src/public/Attachment.ts
@@ -60,7 +60,6 @@ export function upload(
   const headerParams = {
     ...args[2],
     "Content-Type": args[2]?.["Content-Type"] ?? args[0].type,
-    "Content-Length": args[0].size.toString(),
   };
 
   return $foundryPlatformFetch($ctx, _upload, args[0], args[1], headerParams);
@@ -102,7 +101,6 @@ export function uploadWithRid(
   const headerParams = {
     ...args[3],
     "Content-Type": args[3]?.["Content-Type"] ?? args[1].type,
-    "Content-Length": args[1].size.toString(),
   };
 
   return $foundryPlatformFetch(

--- a/packages/internal.foundry.ontologies/src/public/Attachment.ts
+++ b/packages/internal.foundry.ontologies/src/public/Attachment.ts
@@ -60,7 +60,6 @@ export function upload(
   const headerParams = {
     ...args[2],
     "Content-Type": args[2]?.["Content-Type"] ?? args[0].type,
-    "Content-Length": args[0].size.toString(),
   };
 
   return $foundryPlatformFetch($ctx, _upload, args[0], args[1], headerParams);

--- a/packages/internal.foundry.ontologiesv2/src/public/Attachment.ts
+++ b/packages/internal.foundry.ontologiesv2/src/public/Attachment.ts
@@ -63,7 +63,6 @@ export function upload(
   const headerParams = {
     ...args[2],
     "Content-Type": args[2]?.["Content-Type"] ?? args[0].type,
-    "Content-Length": args[0].size.toString(),
   };
 
   return $foundryPlatformFetch($ctx, _upload, args[0], args[1], headerParams);


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Currently a `Content-Length` header is provided in Fetch calls to upload Attachment.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
After his PR, the `Content-Length` header is removed as it is useless and does not correspond to the platform API format of the headers for the API call: https://www.palantir.com/docs/foundry/api/v2/ontologies-v2-resources/attachments/upload-attachment/

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
None, the current state can actually cause errors for NodeJS 24+ since Content-Length should not be included as a header in fetch.

