### PR TITLE
[ScenariosV2] Add `ScenarioReferenceType` and `hasScenarioRule` to IR and Spec

### DIFF
--- a/.changeset/scenario-reference-docs-ir.md
+++ b/.changeset/scenario-reference-docs-ir.md
@@ -1,0 +1,5 @@
+---
+"@osdk/docs-spec-sdk": minor
+---
+
+Add scenario-reference action parameter IR and scenario-rule template metadata.

--- a/packages/docs-spec-sdk/src/commonIr.ts
+++ b/packages/docs-spec-sdk/src/commonIr.ts
@@ -16,6 +16,7 @@
 
 type BooleanValueType = { type: "boolean"; value: boolean };
 type StringType = { type: "string"; value: string };
+type ScenarioReferenceType = { type: "scenarioReference"; rid: string };
 type DateType = { type: "date"; daysOffset: number };
 type TimestampType = { type: "timestamp"; daysOffset: number };
 type IntegerValueType = { type: "integer"; value: number };
@@ -58,6 +59,7 @@ export type ActionParameterSampleValueTypeIR =
   | DateType
   | TimestampType
   | StringType
+  | ScenarioReferenceType
   | ObjectType
   | ObjectSetType
   | AttachmentType

--- a/packages/docs-spec-sdk/src/spec.ts
+++ b/packages/docs-spec-sdk/src/spec.ts
@@ -132,6 +132,7 @@ const ActionTemplateStrings = {
   actionEditAddedLinksCount: "required",
   actionEditDeletedLinksCount: "required",
   hasEditObjectTypes: "required",
+  hasScenarioRule: "required",
   hasParameters: "required",
   rawActionTypeParameterValues: "required",
   hasAttachmentProperty: "required",


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Not having published these, we could not properly render the generated OSDK documentation for actions that use the `Apply Scenario` rule for [scenario merge](https://www.palantir.com/docs/foundry/ontology/merge-scenario/).

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
[ScenariosV2] Add `ScenarioReference` and `hasScenarioRule` to IR and Docs
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
None